### PR TITLE
no socket before Game component

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,4 +1,5 @@
-html {
+html,
+body {
   background-color: #d0edf5;
 }
 

--- a/src/components/Lobby/Lobby.js
+++ b/src/components/Lobby/Lobby.js
@@ -1,122 +1,30 @@
 /* eslint-disable no-console */
 import React, { useContext } from 'react';
-import { useForm } from '@mantine/form';
-import { Button, TextInput, Container } from '@mantine/core';
+import { Button, Container, Title } from '@mantine/core';
 import { GameContext } from 'contexts/GameContext';
 import { useFirebaseAuth } from 'contexts/FirebaseContext';
 
 const Lobby = () => {
   const gameState = useContext(GameContext);
   const { socket } = gameState;
-  const { playerName } = gameState.playerName;
-  const { roomId, setRoomId } = gameState.roomId;
-  const { host, setHost } = gameState.host;
+  const { roomId } = gameState.roomId;
+  const { host } = gameState.host;
   const { joinedGame } = gameState.joinedGame;
-  const { playerList } = gameState.playerList;
-  const { setErrors } = gameState.errors;
-  // const { storedPlayerName, setStoredPlayerName } = gameState.storedPlayerName;
-  // const { storedRoomId, setStoredRoomId } = gameState.storedRoomId;
-  // const { storedPlayerList, setStoredPlayerList } = gameState.storedPlayerList;
   const user = useFirebaseAuth();
-
-  // const [rejoin, setRejoin] = useState(false);
-
-  // useEffect(() => {
-  //   setStoredPlayerName(window.sessionStorage.getItem('playerName'));
-  //   setStoredRoomId(window.sessionStorage.getItem('roomId'));
-  //   setStoredPlayerList(window.sessionStorage.getItem('playerList') || []);
-  // }, []);
-
-  // useEffect(() => {
-  //   if (storedPlayerName && storedRoomId && storedPlayerList.length) {
-  //     setRejoin(true);
-  //   }
-  //   return () => {
-  //     setRejoin(false);
-  //   };
-  // }, [storedPlayerName, storedRoomId, storedPlayerList]);
-
-  /** Tell the server to create a new game */
-  const createNewGame = () => {
-    if (playerName) {
-      socket.emit('hostCreateNewGame', { playerName, hostId: user?.uid || null });
-      setHost(true);
-    } else {
-      setErrors((prevErrors) => [...prevErrors, 'You must provide a username.']);
-    }
-  };
 
   /** Tell server to begin game */
   const roomFull = () => {
     socket.emit('hostRoomFull', roomId);
   };
 
-  /** Attempt to join a game by game ID */
-  const joinGame = ({ playerName, roomId }) => {
-    if (playerName && roomId) {
-      console.log(`Attempting to join game ${roomId} as ${playerName} with clientId ${user?.uid}`);
-      socket.emit('playerJoinGame', {
-        playerName,
-        clientId: user?.uid || null,
-        joinRoomId: roomId,
-        playerList
-      });
-      setRoomId(roomId);
-    } else {
-      setErrors((prevErrors) => [
-        ...prevErrors,
-        'You must provide both a game number and a player name.'
-      ]);
-    }
-  };
-
-  // /** Attempt to rejoin a game by game ID */
-  // const rejoinGame = (e) => {
-  //   e.preventDefault();
-  //   if (storedPlayerName && storedRoomId) {
-  //     console.log(`Attempting to rejoin game ${roomId} as ${playerName}`);
-  //     socket.emit('playerRejoinGame', {
-  //       storedPlayerName,
-  //       storedRoomId,
-  //       storedPlayerList
-  //     });
-  //   } else {
-  //     console.error('playerName and storedRoomId not stored, cannot rejoin game.');
-  //   }
-  // };
-
-  const form = useForm({
-    initialValues: {
-      // these keys must match the input keys for joinGame
-      playerName,
-      roomId
-    }
-  });
-
-  // eslint-disable-next-line no-unused-vars
-  const handleError = (_errors) => {
-    console.log('Form error handled serverside');
-  };
-  const handleSubmit = (values) => {
-    joinGame(values);
-  };
   return (
     <Container style={{ backgroundColor: '#d0edf5' }}>
-      {
-        /** There is no assigned room, give option to create room */
-        roomId ? null : (
-          <Button variant="success" onClick={createNewGame} style={{ width: '12em' }}>
-            Create New Game
-          </Button>
-        )
-      }
-
       {
         /** You have joined the game and are waiting for the host to start */
         joinedGame && !host ? (
           <>
-            <h3>請等主持人</h3>
-            <h3>Waiting for the host</h3>
+            <Title order={3}>請等主持人</Title>
+            <Title order={3}>Waiting for the host</Title>
           </>
         ) : null
       }
@@ -125,8 +33,8 @@ const Lobby = () => {
         /** Give host ability to start game */
         host ? (
           <>
-            <h3>按 &quot;Room Full&quot; 開始遊戲</h3>
-            <h3>Click &quot;Room Full&quot; to begin the game</h3>
+            <Title order={3}>按 &quot;Room Full&quot; 開始遊戲</Title>
+            <Title order={3}>Click &quot;Room Full&quot; to begin the game</Title>
             <Button type="button" variant="success" onClick={roomFull} style={{ width: '8em' }}>
               Room Full
             </Button>
@@ -138,35 +46,13 @@ const Lobby = () => {
         /** Not host and haven't joined a game, give option to join game */
         host || joinedGame ? null : (
           <>
-            {/* disabled until fully implemented */}
-            {/* {rejoin ? (
-              <Button variant="warning" onClick={rejoinGame}>
-                Rejoin
-              </Button>
-            ) : null} */}
             {user ? (
               <>
-                <h2>Hello {user.email}</h2>
+                <Title order={2}>Hello {user.email}</Title>
               </>
             ) : (
-              <div />
+              <Container />
             )}
-            <form onSubmit={form.onSubmit(handleSubmit, handleError)}>
-              <TextInput
-                label="Player name:"
-                placeholder="Ex. Ian"
-                {...form.getInputProps('playerName')}
-              />
-              <TextInput
-                label="Join game:"
-                placeholder="Ex. 12345"
-                {...form.getInputProps('roomId')}
-              />
-              <br />
-              <Button variant="info" type="submit">
-                Submit
-              </Button>
-            </form>
           </>
         )
       }

--- a/src/contexts/GameContext.js
+++ b/src/contexts/GameContext.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 import React, { createContext, useState, useEffect } from 'react';
+import { useNavigate } from 'react-router';
 import { io } from 'socket.io-client';
 import { uniqueNamesGenerator, colors, animals } from 'unique-names-generator';
 
@@ -11,6 +12,8 @@ export const GameContext = createContext({});
 
 // eslint-disable-next-line react/prop-types
 export const GameProvider = ({ children }) => {
+  const navigate = useNavigate();
+
   /** user-input: the user's name */
   const defaultName = uniqueNamesGenerator({
     dictionaries: [colors, animals],
@@ -61,7 +64,6 @@ export const GameProvider = ({ children }) => {
   const [winner, setWinner] = useState(null);
   const [gameResults, setGameResults] = useState({ remain: [[], []], lost: [[], []] });
 
-  // const [startingBoard, setStartingBoard] = useState();
   const [errors, setErrors] = useState([]);
 
   const gameState = {
@@ -107,8 +109,8 @@ export const GameProvider = ({ children }) => {
     socket.on('newGameCreated', ({ gameId, mySocketId, players }) => {
       console.log(`GameID: ${gameId}, SocketID: ${mySocketId}`);
       setRoomId(gameId);
-      // setJoinRoomId(gameId);
       setPlayerList(players);
+      navigate('/game');
     });
 
     /** Server is telling all clients the game has started  */
@@ -129,6 +131,7 @@ export const GameProvider = ({ children }) => {
     socket.on('youHaveJoinedTheRoom', (data) => {
       setJoinedGame(true);
       setPlayerList(data.players);
+      navigate('/game');
       window.sessionStorage.setItem('playerName', playerName);
       window.sessionStorage.setItem('roomId', roomId);
       window.sessionStorage.setItem('playerList', data.players);

--- a/src/views/Game.js
+++ b/src/views/Game.js
@@ -1,11 +1,11 @@
 /* eslint-disable react/prop-types */
 import React, { useContext, useEffect } from 'react';
 import { GameContext } from 'contexts/GameContext';
+import { ToastContainer, toast } from 'react-toastify';
 
 import Lobby from 'components/Lobby';
 import BoardSetup from 'components/BoardSetup';
 import GameOver from 'components/GameOver';
-import { ToastContainer, toast } from 'react-toastify';
 import GameBoard from 'components/GameBoard';
 import { useFirebaseAuth } from 'contexts/FirebaseContext';
 

--- a/src/views/Menu.js
+++ b/src/views/Menu.js
@@ -1,10 +1,47 @@
-import React from 'react';
+import React, { useContext, useEffect } from 'react';
+import { GameContext } from 'contexts/GameContext';
 import { Link } from 'react-router-dom';
-import { Button, Container } from '@mantine/core';
+import { ToastContainer, toast } from 'react-toastify';
+import { Button, Container, TextInput } from '@mantine/core';
+import { useFirebaseAuth } from 'contexts/FirebaseContext';
+import { useForm } from '@mantine/form';
+import { Title } from '@mantine/core';
 
 function Menu() {
+  const {
+    socket,
+    playerName: { playerName },
+    roomId: { roomId, setRoomId },
+    playerList: { playerList },
+    host: { setHost },
+    errors: { errors, setErrors }
+  } = useContext(GameContext);
+
+  const createForm = useForm({
+    initialValues: { playerName }
+  });
+
+  const joinForm = useForm({
+    initialValues: {
+      // these keys must match the input keys for joinGame
+      playerName,
+      roomId
+    }
+  });
+
+  const user = useFirebaseAuth();
+
+  /** Clear errors after 1 second each */
+  useEffect(() => {
+    errors.forEach((error) => {
+      toast.error(error, {
+        toastId: `${Date.now()}`
+      });
+    });
+    setErrors([]);
+  }, [JSON.stringify(errors), toast.error]);
+
   const viewStyle = {
-    height: '100vh',
     backgroundColor: '#d0edf5',
     display: 'flex',
     flexDirection: 'column',
@@ -28,34 +65,101 @@ function Menu() {
   };
   const linkStyle = { color: 'white' };
 
+  /** Tell the server to create a new game */
+  const createNewGame = (name) => {
+    if (name) {
+      socket.emit('hostCreateNewGame', { playerName: name, hostId: user?.uid || null });
+      setHost(true);
+      // GameContext will redirect to /game when socket starts the game
+    } else {
+      setErrors((prevErrors) => [...prevErrors, 'You must provide a player name.']);
+    }
+  };
+
+  /** Attempt to join a game by game ID */
+  const joinGame = (playerName, roomId) => {
+    if (playerName && roomId) {
+      console.log(`Attempting to join game ${roomId} as ${playerName} with clientId ${user?.uid}`);
+      socket.emit('playerJoinGame', {
+        playerName,
+        clientId: user?.uid || null,
+        joinRoomId: roomId,
+        playerList
+      });
+      setRoomId(roomId);
+    } else {
+      setErrors((prevErrors) => [
+        ...prevErrors,
+        'You must provide both a game number and a player name.'
+      ]);
+    }
+  };
+
+  const handleCreateSubmit = ({ playerName }) => {
+    createNewGame(playerName);
+    setErrors((prevErrors) => [...prevErrors, 'Unable to connect to server.']);
+  };
+
+  const handleJoinSubmit = ({ playerName, roomId }) => {
+    joinGame(playerName, roomId);
+    setErrors((prevErrors) => [...prevErrors, 'Unable to connect to server.']);
+  };
+
   return (
-    <div style={viewStyle}>
-      <Container style={stackStyle}>
-        <Container style={cardStyle}>
-          <h2>Host a New Game</h2>
-          <Link to="/game" style={linkStyle}>
-            <Button>Create Match</Button>
-          </Link>
-        </Container>
-        <Container style={cardStyle}>
-          <h2>Join an Existing Game</h2>
-          <Link to="/game" style={linkStyle}>
-            <Button>Join Match</Button>
-          </Link>
-        </Container>
-        <Container style={cardStyle}>
-          <h2>For Developers</h2>
-          <Container style={cardContentStyle}>
-            <Link to="/setup-test" style={linkStyle}>
-              <Button>Test Setup</Button>
-            </Link>
-            <Link to="/gameboard-test" style={linkStyle}>
-              <Button>Test New Board</Button>
-            </Link>
+    <>
+      <Container style={viewStyle}>
+        <Container style={stackStyle}>
+          <Container style={cardStyle}>
+            <Title order={3}>Host a New Game</Title>
+            <form onSubmit={createForm.onSubmit(handleCreateSubmit)}>
+              <TextInput
+                label="Player name:"
+                placeholder="Ex. Ian"
+                {...createForm.getInputProps('playerName')}
+              />
+              <br />
+              <Button variant="info" type="submit">
+                Create Match
+              </Button>
+            </form>
+          </Container>
+          <Container style={cardStyle}>
+            <Title order={3}>Join a Game</Title>
+            {/* <Link to="/game" style={linkStyle}>
+              <Button>Join Match</Button>
+            </Link> */}
+            <form onSubmit={joinForm.onSubmit(handleJoinSubmit)}>
+              <TextInput
+                label="Player name:"
+                placeholder="Ex. Ian"
+                {...joinForm.getInputProps('playerName')}
+              />
+              <TextInput
+                label="Join game:"
+                placeholder="Ex. 12345"
+                {...joinForm.getInputProps('roomId')}
+              />
+              <br />
+              <Button variant="info" type="submit">
+                Submit
+              </Button>
+            </form>
+          </Container>
+          <Container style={cardStyle}>
+            <Title order={3}>For developers</Title>
+            <Container style={cardContentStyle}>
+              <Link to="/setup-test" style={linkStyle}>
+                <Button>Test Setup</Button>
+              </Link>
+              <Link to="/gameboard-test" style={linkStyle}>
+                <Button>Test New Board</Button>
+              </Link>
+            </Container>
           </Container>
         </Container>
       </Container>
-    </div>
+      <ToastContainer />
+    </>
   );
 }
 


### PR DESCRIPTION
# Description

The player can now create or join a game from the landing page.

The player only enters the `Lobby` (part of `Game`) after a socket connection is established.

A connection error is gracefully shown to the user via `toast` if a socket connection cannot be established when creating or joining a game.

Formerly, the player could click `Create new game` in `Game` before the socket connection, when connection to the server was lost, resulting in a `Game` component without a `roomId`. This is no longer possible in this implementation.

No backend changes were required.

![image](https://github.com/chinese-board-games/luzhanqi-web/assets/45278651/0e549c14-c19b-4a42-91b5-e94d3da62384)

![image](https://github.com/chinese-board-games/luzhanqi-web/assets/45278651/55531a40-ecea-48b3-a5d2-509c494d6000)


## Type of Change

- [X] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

## Screenshots

Please attach any design screenshots if UI update.
