### PR TITLE
prevent duplicate game history when user plays game against themselves

### DIFF
--- a/src/components/UserModal/UserModal.js
+++ b/src/components/UserModal/UserModal.js
@@ -37,7 +37,11 @@ const UserModal = ({ showModal, setShowModal }) => {
         })
       );
       console.log('games loaded');
-      setGameData(myGames);
+      // do not load a game with a certain _id more than once
+      const myUniqueGames = myGames.filter(
+        (v, i, a) => a.findIndex((v2) => v2._id === v._id) === i
+      );
+      setGameData(myUniqueGames);
     };
 
     if (user) {
@@ -46,6 +50,7 @@ const UserModal = ({ showModal, setShowModal }) => {
     }
   }, [setUserData, user?.uid, showModal]);
 
+  console.log(gameData);
   return (
     <Modal
       ariaHideApp={false}
@@ -93,7 +98,11 @@ const UserModal = ({ showModal, setShowModal }) => {
               return (
                 <tr key={myGame._id}>
                   <td>{new Date(myGame.createdAt).toLocaleDateString()}</td>
-                  <td>{myGame.hostId === user?.uid ? myGame.players[1] : myGame.players[0]}</td>
+                  {myGame.hostId && myGame.hostId === myGame.clientId ? (
+                    <td>Yourself</td>
+                  ) : (
+                    <td>{myGame.hostId === user?.uid ? myGame.players[1] : myGame.players[0]}</td>
+                  )}
                   <td>
                     <p>
                       {myGame.winnerId === user?.uid


### PR DESCRIPTION
# Description

When a logged-in user played themselves, their game shows up twice in their game history.

## Type of Change

- [ ] New feature
- [X] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

## Screenshots
### Before change:
![image](https://github.com/chinese-board-games/luzhanqi-web/assets/45278651/2044a432-504a-4b60-9781-fb25bf26a219)
### After change:
<img width="489" alt="Screenshot 2023-10-28 at 2 54 10 PM" src="https://github.com/chinese-board-games/luzhanqi-web/assets/45278651/e651801c-dd9b-43b6-8abd-cb3c510abc77">

Please attach any design screenshots if UI update.
