### PR TITLE
Prevent user from sending board with unplaced pieces

### DIFF
--- a/src/components/BoardSetup/HalfBoard.js
+++ b/src/components/BoardSetup/HalfBoard.js
@@ -1,7 +1,18 @@
 /* eslint-disable react/no-unescaped-entities */
 /* eslint-disable react/prop-types */
 import React, { useState } from 'react';
-import { Container, Flex, Stack, Grid, Center, Title, Group, Button, Box } from '@mantine/core';
+import {
+  Container,
+  Flex,
+  Stack,
+  Grid,
+  Center,
+  Title,
+  Group,
+  Button,
+  Box,
+  Tooltip,
+} from '@mantine/core';
 import {
   DragOverlay,
   closestCenter,
@@ -227,9 +238,17 @@ export default function HalfBoard({ sendStartingBoard, playerList, playerName, i
               <Button type="button" variant="secondary" onClick={setExampleOne}>
                 Set Example 1
               </Button>
-              <Button type="button" variant="info" onClick={() => sendStartingBoard(halfBoard)}>
-                Send Board Placement
-              </Button>
+              <Tooltip label="You still have unplaced pieces!">
+                <span>
+                  <Button
+                    disabled={unplacedPieces.length > 0}
+                    type="button"
+                    variant="info"
+                    onClick={() => sendStartingBoard(halfBoard)}>
+                    Send Board Placement
+                  </Button>
+                </span>
+              </Tooltip>
               <Button
                 type="button"
                 color="red.6"


### PR DESCRIPTION
# Description

Disables button to send board placement if there are still unplaced pieces.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Unit/integration tests
- [x] Documentation

## Screenshots
<img width="805" alt="image" src="https://github.com/chinese-board-games/luzhanqi-web/assets/17861378/2c988df3-d0ec-4688-bd9c-1d7470cfa928">

Please attach any design screenshots if UI update.
