### PR TITLE
Usability fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "popper.js": "^1.16.1",
         "prop-types": "^15.7.2",
         "react": "^17.0.1",
+        "react-beforeunload": "^2.6.0",
         "react-dom": "^17.0.1",
         "react-firebase-hooks": "^5.1.1",
         "react-lineto": "^3.3.0",
@@ -7161,6 +7162,14 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-beforeunload": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-beforeunload/-/react-beforeunload-2.6.0.tgz",
+      "integrity": "sha512-aKrGaRNc7fZQlDnmSYrXu4cbz9QEPhScA4A2mLxhjcULDy4VILLyLhSEjg2goIw3o5LQ1zss44kmQh5LXWYGCw==",
+      "peerDependencies": {
+        "react": "^16.8.0 || 17 || 18"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "popper.js": "^1.16.1",
     "prop-types": "^15.7.2",
     "react": "^17.0.1",
+    "react-beforeunload": "^2.6.0",
     "react-dom": "^17.0.1",
     "react-firebase-hooks": "^5.1.1",
     "react-lineto": "^3.3.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,23 +1,44 @@
-import React from 'react';
+import React, { useEffect, useContext } from 'react';
 import { Routes, Route } from 'react-router-dom';
-import 'bootstrap/dist/css/bootstrap.min.css';
+import { GameContext } from 'contexts/GameContext';
+
 import NavBar from 'components/NavBar';
 import Menu from './views/Menu';
 import Game from './views/Game';
 import SetupTest from './views/SetupTest';
 import GameBoardTest from './views/GameBoardTest';
+import { ToastContainer, toast } from 'react-toastify';
+
+import 'bootstrap/dist/css/bootstrap.min.css';
 import './App.css';
 
-const App = () => (
-  <>
-    <NavBar />
-    <Routes>
-      <Route path="/game/:roomId" element={<Game />} />
-      <Route path="/setup-test" element={<SetupTest />} />
-      <Route path="/gameboard-test" element={<GameBoardTest />} />
-      <Route path="/*" element={<Menu />} />
-    </Routes>
-  </>
-);
+const App = () => {
+  const {
+    errors: { errors, setErrors },
+  } = useContext(GameContext);
+
+  /** Clear errors after 1 second each */
+  useEffect(() => {
+    errors.forEach((error) => {
+      toast.error(error, {
+        toastId: error,
+      });
+    });
+    setErrors([]);
+  }, [JSON.stringify(errors), toast.error]);
+
+  return (
+    <>
+      <NavBar />
+      <Routes>
+        <Route path="/game/:roomId" element={<Game />} />
+        <Route path="/setup-test" element={<SetupTest />} />
+        <Route path="/gameboard-test" element={<GameBoardTest />} />
+        <Route path="/*" element={<Menu />} />
+      </Routes>
+      <ToastContainer />
+    </>
+  );
+};
 
 export default App;

--- a/src/components/GameBoard/DeadPieces.jsx
+++ b/src/components/GameBoard/DeadPieces.jsx
@@ -1,21 +1,41 @@
 /* eslint-disable react/prop-types */
-import { Container, Flex, Title } from '@mantine/core';
+import { Flex, Stack, Title } from '@mantine/core';
 import Piece from 'components/Piece';
 
-export default function DeadPieces({ deadPieces, isEnglish }) {
+export default function DeadPieces({ deadPieces = [], affiliation, isEnglish }) {
+  const friendlyDead = deadPieces.filter((piece) => piece.affiliation === affiliation);
+  const enemyDead = deadPieces.filter((piece) => piece.affiliation !== affiliation);
+
+  const DisplayDead = ({ dead, title }) => {
+    return (
+      <>
+        {dead.length ? <Title order={4}>{title}</Title> : null}
+        <Flex style={{ width: '16em', gap: '0.5em', flexWrap: 'wrap', marginBottom: '2em' }}>
+          {dead.map((piece, idx) => (
+            <Piece
+              key={`${title}_${piece.id}_${idx}`}
+              name={piece.name}
+              affiliation={piece.affiliation}
+              isEnglish={isEnglish}
+            />
+          ))}
+        </Flex>
+      </>
+    );
+  };
+
   return (
-    <Container style={{ marginTop: '0.5em' }}>
-      <Title order={3}>Dead pieces</Title>
-      <Flex style={{ gap: '0.5em', flexWrap: 'wrap', marginBottom: '2em' }}>
-        {deadPieces.map((piece) => (
-          <Piece
-            key={piece.id}
-            name={piece.name}
-            affiliation={piece.affiliation}
-            isEnglish={isEnglish}
-          />
-        ))}
-      </Flex>
-    </Container>
+    <Stack style={{ marginTop: '1em', gap: '0.5em' }}>
+      {affiliation === -1 ? (
+        <>
+          <DisplayDead dead={deadPieces} title="Dead" />
+        </>
+      ) : (
+        <>
+          <DisplayDead dead={enemyDead} title="Enemy dead" />
+          <DisplayDead dead={friendlyDead} title="Friendly dead" />
+        </>
+      )}
+    </Stack>
   );
 }

--- a/src/components/GameBoard/FrontLines.jsx
+++ b/src/components/GameBoard/FrontLines.jsx
@@ -1,6 +1,7 @@
+import PropTypes from 'prop-types';
 import { Center, Stack, Text } from '@mantine/core';
 
-export default function FrontLines() {
+export default function FrontLines({ isEnglish }) {
   return (
     <Center
       sx={(theme) => ({
@@ -20,9 +21,15 @@ export default function FrontLines() {
       h="4em"
     >
       <Stack sx={{ gap: '0' }}>
-        <Text sx={{ rotate: '180deg', fontFamily: 'SentyWEN2017' }}>前綫</Text>
-        <Text sx={{ fontFamily: 'SentyWEN2017' }}>前綫</Text>
+        <Text sx={{ rotate: '180deg', fontFamily: 'SentyWEN2017' }}>
+          {isEnglish ? 'FRONT' : '前綫'}
+        </Text>
+        <Text sx={{ fontFamily: 'SentyWEN2017' }}>{isEnglish ? 'FRONT' : '前綫'}</Text>
       </Stack>
     </Center>
   );
 }
+
+FrontLines.propTypes = {
+  isEnglish: PropTypes.bool.isRequired,
+};

--- a/src/components/GameBoard/Mountain.jsx
+++ b/src/components/GameBoard/Mountain.jsx
@@ -1,7 +1,7 @@
 import { Center } from '@mantine/core';
 import PropTypes from 'prop-types';
 
-export default function Mountain({ rotation }) {
+export default function Mountain({ rotation, isEnglish }) {
   return (
     <Center
       sx={(theme) => ({
@@ -11,7 +11,7 @@ export default function Mountain({ rotation }) {
         fontSize: theme.other.mountainSizing.md.fontSize,
         zIndex: 100,
         whiteSpace: 'nowrap',
-        rotate: rotation || '0deg',
+        rotate: isEnglish ? '-90deg' : rotation,
         fontFamily: 'SentyWEN2017',
         '@media (max-width: 450px)': {
           fontSize: theme.other.mountainSizing.sm.fontSize,
@@ -24,11 +24,12 @@ export default function Mountain({ rotation }) {
       w="4em"
       h="4em"
     >
-      山界
+      {isEnglish ? 'MTN' : '山界'}
     </Center>
   );
 }
 
 Mountain.propTypes = {
-  rotation: PropTypes.string,
+  rotation: PropTypes.string.isRequired,
+  isEnglish: PropTypes.bool.isRequired,
 };

--- a/src/components/GameBoard/index.jsx
+++ b/src/components/GameBoard/index.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Grid, Container, Center, Stack, Button, Group } from '@mantine/core';
+import { Grid, Container, Center, Stack, Button, Group, Flex } from '@mantine/core';
 import { emptyBoard } from 'utils/core';
 import SelectablePosition from '../SelectablePosition';
 import { isEqual } from 'lodash';
@@ -108,11 +108,11 @@ export default function GameBoard({
   );
 
   const divider = [
-    <FrontLines key="1" />,
-    <Mountain rotation="-90deg" key="2" />,
-    <FrontLines key="3" />,
-    <Mountain rotation="90deg" key="4" />,
-    <FrontLines key="5" />,
+    <FrontLines key="1" isEnglish={isEnglish} />,
+    <Mountain rotation="-90deg" key="2" isEnglish={isEnglish} />,
+    <FrontLines key="3" isEnglish={isEnglish} />,
+    <Mountain rotation="90deg" key="4" isEnglish={isEnglish} />,
+    <FrontLines key="5" isEnglish={isEnglish} />,
   ].map((content, i) => (
     <Grid.Col key={`divider-${i}`} span={4}>
       <Center mih="5em">{content}</Center>
@@ -126,8 +126,8 @@ export default function GameBoard({
   ];
 
   return (
-    <>
-      <Container bg="rgb(224, 224, 224)" sx={{ borderRadius: '1em' }} p="1em 2em" maw="40em">
+    <Flex wrap={'wrap'} align={'center'}>
+      <Container bg="#f0f8ff" sx={{ borderRadius: '1em' }} p="1em 2em" maw="40em">
         {isSpectator || gamePhase > 2 ? null : (
           <Center py="1em">
             <Stack>
@@ -163,8 +163,8 @@ export default function GameBoard({
         <ConnectionLines />
         <Grid columns={20}>{combined.map((cell) => cell)}</Grid>
       </Container>
-      <DeadPieces deadPieces={deadPieces} isEnglish={isEnglish} />
-    </>
+      <DeadPieces deadPieces={deadPieces} affiliation={affiliation} isEnglish={isEnglish} />
+    </Flex>
   );
 }
 

--- a/src/components/GameBoard/index.jsx
+++ b/src/components/GameBoard/index.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Grid, Container, Center, Stack, Button, Group, Flex } from '@mantine/core';
 import { emptyBoard } from 'utils/core';
+import WarnModal from 'components/WarnModal';
 import SelectablePosition from '../SelectablePosition';
 import { isEqual } from 'lodash';
 import FrontLines from './FrontLines';
@@ -26,6 +27,8 @@ export default function GameBoard({
 }) {
   const [origin, setOrigin] = useState(NO_SELECT);
   const [destination, setDestination] = useState(NO_SELECT);
+
+  const [showWarnModal, setShowWarnModal] = useState(false);
 
   const originSelected = !isEqual(origin, NO_SELECT);
   const destinationSelected = !isEqual(destination, NO_SELECT);
@@ -152,7 +155,7 @@ export default function GameBoard({
                 >
                   Reset move
                 </Button>
-                <Button variant="filled" color="red" onClick={forfeit}>
+                <Button variant="filled" color="red" onClick={() => setShowWarnModal(true)}>
                   Forfeit
                 </Button>
               </Group>
@@ -164,6 +167,7 @@ export default function GameBoard({
         <Grid columns={20}>{combined.map((cell) => cell)}</Grid>
       </Container>
       <DeadPieces deadPieces={deadPieces} affiliation={affiliation} isEnglish={isEnglish} />
+      <WarnModal showModal={showWarnModal} setShowModal={setShowWarnModal} forfeit={forfeit} />
     </Flex>
   );
 }

--- a/src/components/Lobby/Lobby.jsx
+++ b/src/components/Lobby/Lobby.jsx
@@ -1,8 +1,7 @@
-import React, { useContext, useEffect } from 'react';
+import React, { useContext } from 'react';
 import { Button, Checkbox, Container, Title } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { GameContext } from 'contexts/GameContext';
-import { ToastContainer, toast } from 'react-toastify';
 import { useFirebaseAuth } from 'contexts/FirebaseContext';
 
 const Lobby = () => {
@@ -15,7 +14,7 @@ const Lobby = () => {
     spectatorList: { spectatorList },
     host: { host },
     joinedGame: { joinedGame },
-    errors: { errors, setErrors },
+    errors: { setErrors },
   } = useContext(GameContext);
 
   const user = useFirebaseAuth();
@@ -24,16 +23,6 @@ const Lobby = () => {
       fogOfWar: true,
     },
   });
-
-  /** Clear errors after 1 second each */
-  useEffect(() => {
-    errors.forEach((error) => {
-      toast.error(error, {
-        toastId: `${Date.now()}`,
-      });
-    });
-    setErrors([]);
-  }, [JSON.stringify(errors), toast.error]);
 
   /** Tell server to begin game */
   const roomFull = (gameConfig) => {
@@ -114,8 +103,6 @@ const Lobby = () => {
           </>
         ) : null
       }
-
-      <ToastContainer />
     </Container>
   );
 };

--- a/src/components/NavBar/NavBar.jsx
+++ b/src/components/NavBar/NavBar.jsx
@@ -4,6 +4,7 @@ import { Button, ActionIcon, Flex, Title } from '@mantine/core';
 import { IconUserSquareRounded } from '@tabler/icons-react';
 
 import { useAuthState } from 'react-firebase-hooks/auth';
+import { useBeforeunload } from 'react-beforeunload';
 
 import { GameContext } from 'contexts/GameContext';
 import AuthModal from 'components/AuthModal';
@@ -42,6 +43,14 @@ const NavBar = () => {
     isEnglish: { isEnglish, setIsEnglish },
     errors: { setErrors },
   } = React.useContext(GameContext);
+
+  useBeforeunload((event) => {
+    if (gamePhase == 2) {
+      setShowWarnModal(true);
+      event.preventDefault();
+    }
+    return;
+  });
 
   const forfeit = () => {
     socket.emit('playerForfeit', {

--- a/src/components/NavBar/NavBar.jsx
+++ b/src/components/NavBar/NavBar.jsx
@@ -51,6 +51,9 @@ const NavBar = () => {
   };
 
   const resetToLanding = () => {
+    if (!roomId) {
+      return;
+    }
     if (gamePhase == 2) {
       setShowWarnModal(true);
       return;
@@ -136,7 +139,7 @@ const NavBar = () => {
             </ActionIcon>
 
             <Button
-              size="compact-md"
+              size="compact-lg"
               color="red"
               onClick={() => {
                 getAuth().signOut();
@@ -147,17 +150,17 @@ const NavBar = () => {
             </Button>
           </>
         ) : (
-          <Button size="compact-md" onClick={() => setShowAuthModal(true)}>
+          <Button size="compact-lg" onClick={() => setShowAuthModal(true)}>
             Sign In/Sign Up
           </Button>
         )}
         <Button
-          size="compact-sm"
+          size="compact-lg"
           color="green"
-          style={{ width: '3em' }}
+          style={{ width: '3.7em' }}
           onClick={() => setIsEnglish(!isEnglish)}
         >
-          {isEnglish ? '中文' : 'en'}
+          {isEnglish ? '中文' : 'ENG'}
         </Button>
       </Flex>
 

--- a/src/components/Piece/index.jsx
+++ b/src/components/Piece/index.jsx
@@ -27,7 +27,7 @@ export default function Piece({ name, affiliation, isEnglish }) {
         },
       })}
     >
-      <Text sx={{ fontFamily: 'SentyWEN2017' }} color={affiliation === 0 ? 'indigo.7' : 'red.7'}>
+      <Text sx={{ fontFamily: 'SentyWEN2017' }} color={affiliation === 0 ? '#047495' : '#900000'}>
         {isEnglish ? piece.english : piece.display}
       </Text>
     </Center>

--- a/src/components/Position.jsx
+++ b/src/components/Position.jsx
@@ -54,7 +54,7 @@ export default function Position({
           sx={(theme) => ({
             borderRadius: '100%',
             border: '.1em solid black',
-            writingMode: 'vertical-rl',
+            writingMode: isEnglish ? 'horizontal-tb' : 'vertical-rl',
             zIndex: 100,
             filter: disabled && disabledFilter,
             whiteSpace: 'nowrap',
@@ -69,7 +69,7 @@ export default function Position({
             },
           })}
         >
-          {placedPiece || '行營'}
+          {placedPiece || (isEnglish ? 'SAFE' : '行營')}
         </Center>
       );
     }
@@ -106,8 +106,14 @@ export default function Position({
           <Stack spacing="0em" align="stretch" justify="center">
             {placedPiece || (
               <>
-                <Center sx={{ lineHeight: '1.1' }}>大</Center>
-                <Center sx={{ lineHeight: '1.1' }}>本營</Center>
+                {isEnglish ? (
+                  <Center sx={{ lineHeight: '1.1' }}>BASE</Center>
+                ) : (
+                  <>
+                    <Center sx={{ lineHeight: '1.1' }}>大</Center>
+                    <Center sx={{ lineHeight: '1.1' }}>本營</Center>
+                  </>
+                )}
               </>
             )}
           </Stack>
@@ -141,7 +147,7 @@ export default function Position({
         })}
         bg="pastel-tan.1"
       >
-        {placedPiece || '後勤'}
+        {placedPiece || (isEnglish ? 'LAND' : '後勤')}
       </Center>
     );
   };

--- a/src/components/WarnModal/WarnModal.jsx
+++ b/src/components/WarnModal/WarnModal.jsx
@@ -32,7 +32,7 @@ const WarnModal = ({ showModal, setShowModal, forfeit }) => (
       </Button>
     </Flex>
     <Title order={2}>Are you sure?</Title>
-    <Text>To leave a game in-progress is to forfeit the game.</Text>
+    <Text>You will forfeit the game.</Text>
     <br />
     <Flex style={{ gap: '0.25em', justifyContent: 'flex-end' }}>
       <Button
@@ -45,7 +45,7 @@ const WarnModal = ({ showModal, setShowModal, forfeit }) => (
         Forfeit
       </Button>
       <Button color="green" onClick={() => setShowModal(false)}>
-        Return to game
+        Keep playing
       </Button>
     </Flex>
   </Modal>

--- a/src/contexts/GameContext.jsx
+++ b/src/contexts/GameContext.jsx
@@ -210,11 +210,14 @@ export const GameProvider = ({ children }) => {
       setWinner(winnerIndex);
       setGameResults(gameStats);
       setMyBoard(finalGame.board);
+      setMyDeadPieces(finalGame.deadPieces);
     });
 
     /** Server is returning an error message to the client */
     socket.on('error', (errMsg) => {
-      pushErrors(errMsg);
+      if (!errors.includes(errMsg)) {
+        pushErrors(errMsg);
+      }
     });
 
     return () => {

--- a/src/contexts/GameContext.jsx
+++ b/src/contexts/GameContext.jsx
@@ -44,6 +44,7 @@ export const GameProvider = ({ children }) => {
   });
   const [successors, setSuccessors] = useState([]);
   const [isEnglish, setIsEnglish] = useState(false);
+  const [developmentMode, setDevelopmentMode] = useState(false);
 
   /**
    * Game phases:
@@ -93,6 +94,7 @@ export const GameProvider = ({ children }) => {
     winner: { winner, setWinner },
     gameResults: { gameResults, setGameResults },
     isEnglish: { isEnglish, setIsEnglish },
+    developmentMode: { developmentMode, setDevelopmentMode },
     errors: { errors, setErrors },
   };
 

--- a/src/views/Game.jsx
+++ b/src/views/Game.jsx
@@ -52,9 +52,8 @@ const Game = () => {
     }
   };
 
-  const playerForfeit = (e) => {
+  const playerForfeit = () => {
     console.info('Game forfeitted!');
-    e.preventDefault();
     socket.emit('playerForfeit', {
       playerName,
       uid,

--- a/src/views/Game.jsx
+++ b/src/views/Game.jsx
@@ -1,7 +1,6 @@
-import React, { useContext, useEffect } from 'react';
+import React, { useContext } from 'react';
 import { useParams } from 'react-router';
 import { GameContext } from 'contexts/GameContext';
-import { ToastContainer, toast } from 'react-toastify';
 
 import Lobby from 'components/Lobby';
 import Menu from './Menu';
@@ -23,23 +22,13 @@ const Game = () => {
     gamePhase: { gamePhase },
     host: { host },
     clientTurn: { clientTurn },
-    errors: { errors, setErrors },
+    errors: { setErrors },
     myBoard: { myBoard },
     myDeadPieces: { myDeadPieces },
     isEnglish: { isEnglish },
   } = useContext(GameContext);
 
   const affiliation = playerList.indexOf(playerName);
-
-  /** Clear errors after 1 second each */
-  useEffect(() => {
-    errors.forEach((error) => {
-      toast.error(error, {
-        toastId: `${Date.now()}`,
-      });
-    });
-    setErrors([]);
-  }, [JSON.stringify(errors), toast.error]);
 
   const rotateMove = ([row, col]) => {
     return [11 - row, 4 - col];
@@ -109,7 +98,7 @@ const Game = () => {
                     </Center>
                   ))}
                 </Flex>
-                <Title order={2}>Spectators:</Title>
+                {spectatorList.length ? <Title order={2}>Spectators:</Title> : null}
                 <Flex wrap="wrap">
                   {spectatorList.map((name) => (
                     <Center
@@ -177,7 +166,6 @@ const Game = () => {
           ) : null
         }
       </Container>
-      <ToastContainer />
     </>
   );
 };

--- a/src/views/Menu.jsx
+++ b/src/views/Menu.jsx
@@ -14,6 +14,7 @@ function Menu({ joinedRoom = false, urlRoomId = '' }) {
     spectatorName: { spectatorName },
     roomId: { setRoomId },
     host: { setHost },
+    developmentMode: { developmentMode, setDevelopmentMode },
     errors: { setErrors },
   } = useContext(GameContext);
 
@@ -208,17 +209,23 @@ function Menu({ joinedRoom = false, urlRoomId = '' }) {
           {joinedRoom ? null : <CreateForm />}
           <JoinForm urlRoomId={urlRoomId} />
           <SpectateForm urlRoomId={urlRoomId} />
-          <Container style={cardStyle}>
-            <Title order={3}>For developers</Title>
-            <Container style={cardContentStyle}>
-              <Link to="/setup-test" style={linkStyle}>
-                <Button>Test Setup</Button>
-              </Link>
-              <Link to="/gameboard-test" style={linkStyle}>
-                <Button>Test New Board</Button>
-              </Link>
+          <Button
+            style={{ background: 'transparent' }}
+            onClick={() => setDevelopmentMode(!developmentMode)}
+          ></Button>
+          {developmentMode ? (
+            <Container style={cardStyle}>
+              <Title order={3}>For developers</Title>
+              <Container style={cardContentStyle}>
+                <Link to="/setup-test" style={linkStyle}>
+                  <Button>Test Setup</Button>
+                </Link>
+                <Link to="/gameboard-test" style={linkStyle}>
+                  <Button>Test New Board</Button>
+                </Link>
+              </Container>
             </Container>
-          </Container>
+          ) : null}
         </Container>
       </Container>
     </>

--- a/src/views/Menu.jsx
+++ b/src/views/Menu.jsx
@@ -2,7 +2,6 @@ import React, { useContext, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { GameContext } from 'contexts/GameContext';
 import { Link } from 'react-router-dom';
-import { ToastContainer, toast } from 'react-toastify';
 import { Button, Container, TextInput } from '@mantine/core';
 import { useFirebaseAuth } from 'contexts/FirebaseContext';
 import { useForm } from '@mantine/form';
@@ -15,20 +14,10 @@ function Menu({ joinedRoom = false, urlRoomId = '' }) {
     spectatorName: { spectatorName },
     roomId: { setRoomId },
     host: { setHost },
-    errors: { errors, setErrors },
+    errors: { setErrors },
   } = useContext(GameContext);
 
   const user = useFirebaseAuth();
-
-  /** Clear errors after 1 second each */
-  useEffect(() => {
-    errors.forEach((error) => {
-      toast.error(error, {
-        toastId: `${Date.now()}`,
-      });
-    });
-    setErrors([]);
-  }, [JSON.stringify(errors), toast.error]);
 
   useEffect(() => {
     if (urlRoomId) {
@@ -232,7 +221,6 @@ function Menu({ joinedRoom = false, urlRoomId = '' }) {
           </Container>
         </Container>
       </Container>
-      <ToastContainer />
     </>
   );
 }


### PR DESCRIPTION
# Description

Deduped toast errors
Exposed all dead pieces on endGame
Separated dead pieces by affiliation for players
Added English support for the board positions
Adjusted styling for some buttons in NavBar
Changed colors for enemy and friendly piece text

Warn player before component unload (refresh or navigate away)

## Type of Change

- [X] New feature
- [X] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [X] Unit/integration tests
- [X] Documentation

## Screenshots

Please attach any design screenshots if UI update.
`For Developers` section is not visible  
![image](https://github.com/chinese-board-games/luzhanqi-web/assets/45278651/0f8fbe82-3b67-4402-95fe-ea82fc200182)
Board Setup in English mode
![image](https://github.com/chinese-board-games/luzhanqi-web/assets/45278651/b5625b2d-9dbf-4567-92d5-000f0b7e9b05)
Friendly and enemy dead:
![image](https://github.com/chinese-board-games/luzhanqi-web/assets/45278651/cdc291d1-f2aa-4463-aecf-0ebff79df691)
Enemy dead revealed on endGame:
![image](https://github.com/chinese-board-games/luzhanqi-web/assets/45278651/092372c1-055c-476a-86dd-26f19331832d)
Spectator view (can see all dead):
![image](https://github.com/chinese-board-games/luzhanqi-web/assets/45278651/9cb90a1e-a79b-4006-a989-f35b07ad98ce)
Dead pieces are shown at bottom when screen narrows:
![image](https://github.com/chinese-board-games/luzhanqi-web/assets/45278651/a2db03d3-15bf-4813-8602-a6ca51bec0c3)


