### PR TITLE
feat: add session reconnection and single-player vs AI mode

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,1 @@
+VITE_API=http://localhost:4000

--- a/.eslintrc
+++ b/.eslintrc
@@ -44,7 +44,8 @@
         "map": [
           ["contexts", "./src/contexts"],
           ["components", "./src/components"],
-          ["api", "./src/api"]
+          ["api", "./src/api"],
+          ["data", "./src/data"]
         ]
       }
     },

--- a/craco.config.js
+++ b/craco.config.js
@@ -5,7 +5,8 @@ module.exports = {
     alias: {
       contexts: path.resolve(__dirname, 'src/contexts/'),
       components: path.resolve(__dirname, 'src/components/'),
-      api: path.resolve(__dirname, 'src/api/')
-    }
-  }
+      api: path.resolve(__dirname, 'src/api/'),
+      data: path.resolve(__dirname, 'src/data/'),
+    },
+  },
 };

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -6,7 +6,8 @@
       "components/*": ["./src/components/*"],
       "api/*": ["./src/api/*"],
       "hooks/*": ["./src/hooks/*"],
-      "utils/*": ["./src/utils/*"]
+      "utils/*": ["./src/utils/*"],
+      "data/*": ["./src/data/*"]
     }
   },
   "exclude": ["node_modules"]

--- a/src/components/BoardSetup/HalfBoard.jsx
+++ b/src/components/BoardSetup/HalfBoard.jsx
@@ -24,6 +24,7 @@ import {
 import { SortableContext, arrayMove } from '@dnd-kit/sortable';
 import SortablePiece from 'components/SortablePiece';
 import DraggablePiece from 'components/DraggablePiece';
+import GameTooltip from 'components/GameTooltip';
 import LineTo from 'react-lineto';
 import Position from '../Position';
 import { setupPieces, pieces } from '../../models/Piece';
@@ -319,13 +320,20 @@ function PieceSelector({ unplacedPieces, isEnglish }) {
         <SortableContext items={unplacedPieces}>
           <Flex justify="center" align="center" gap="1em" wrap="wrap">
             {unplacedPieces.map((piece) => (
-              <SortablePiece
-                name={piece.name}
-                affiliation={0}
-                id={piece.id}
+              <GameTooltip
                 key={piece.id}
+                pieceName={piece.name}
+                gamePhase={1}
                 isEnglish={isEnglish}
-              />
+                placement="top"
+              >
+                <SortablePiece
+                  name={piece.name}
+                  affiliation={0}
+                  id={piece.id}
+                  isEnglish={isEnglish}
+                />
+              </GameTooltip>
             ))}
           </Flex>
         </SortableContext>

--- a/src/components/GameBoard/index.jsx
+++ b/src/components/GameBoard/index.jsx
@@ -102,6 +102,7 @@ export default function GameBoard({
           }}
           isEnglish={isEnglish}
           disabled={positionDisabled(r, c)}
+          gamePhase={gamePhase}
         />
       </Grid.Col>
     ))

--- a/src/components/GameBoard/index.jsx
+++ b/src/components/GameBoard/index.jsx
@@ -23,6 +23,7 @@ export default function GameBoard({
   isEnglish = false,
   isSpectator = false,
   gamePhase = 2,
+  lastMove = null,
 }) {
   const [origin, setOrigin] = useState(NO_SELECT);
   const [destination, setDestination] = useState(NO_SELECT);
@@ -81,6 +82,9 @@ export default function GameBoard({
             availibleMoves.has(JSON.stringify([r, c]))
           }
           movable={board[r][c] == null && availibleMoves.has(JSON.stringify([r, c]))}
+          isLastMove={
+            !!lastMove && (isEqual(lastMove.source, [r, c]) || isEqual(lastMove.target, [r, c]))
+          }
           onClick={() => {
             // disallow selection if not your turn
             if (!isTurn) return;
@@ -182,4 +186,8 @@ GameBoard.propTypes = {
   isEnglish: PropTypes.bool,
   isSpectator: PropTypes.bool,
   gamePhase: PropTypes.number,
+  lastMove: PropTypes.shape({
+    source: PropTypes.arrayOf(PropTypes.number),
+    target: PropTypes.arrayOf(PropTypes.number),
+  }),
 };

--- a/src/components/GameTooltip/GameTooltip.jsx
+++ b/src/components/GameTooltip/GameTooltip.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { Tooltip, Text, Box, List, ThemeIcon } from '@mantine/core';
+import { IconInfoCircle } from '@tabler/icons-react';
+import PropTypes from 'prop-types';
+import pieceData from '../../data/pieceData.json';
+
+// map string names from JSON → actual icon components
+import * as Icons from '@tabler/icons-react';
+
+const iconMap = {
+  IconFlag: Icons.IconFlag,
+  IconBomb: Icons.IconBomb,
+  IconShieldHalfFilled: Icons.IconShieldHalfFilled,
+  IconTool: Icons.IconTool,
+  IconUserCircle: Icons.IconUserCircle,
+  IconUser: Icons.IconUser,
+  IconUserShield: Icons.IconUserShield,
+  IconChevronUp: Icons.IconChevronUp,
+  IconBadge: Icons.IconBadge,
+  IconStar: Icons.IconStar,
+  IconMedal: Icons.IconMedal,
+  IconShieldStar: Icons.IconShieldStar,
+  IconCrown: Icons.IconCrown,
+};
+
+const pieceInfo = Object.fromEntries(
+  pieceData.map((piece) => [
+    piece.id,
+    {
+      ...piece,
+      icon: React.createElement(iconMap[piece.icon] || Icons.IconQuestionMark, { size: 16 }),
+    },
+  ])
+);
+
+const GameTooltip = ({
+  children,
+  pieceName,
+  placement = 'top',
+  showTooltips = true, // <-- TODO: toggle isn't currently used
+}) => {
+  const info = pieceInfo[pieceName];
+
+  if (!showTooltips || !info) return children; // respect toggle
+
+  const tooltipContent = (
+    <Box>
+      <Box style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+        <ThemeIcon color="blue" variant="light" size="sm">
+          {info.icon}
+        </ThemeIcon>
+        <Text fw={600} size="sm">
+          {info.title}
+        </Text>
+      </Box>
+      <Text size="xs" c="dimmed" mb="xs">
+        {info.description}
+      </Text>
+      <List size="xs" spacing="xs">
+        {info.rules.map((rule, index) => (
+          <List.Item key={index} icon={<IconInfoCircle size={12} />}>
+            {rule}
+          </List.Item>
+        ))}
+      </List>
+    </Box>
+  );
+
+  return (
+    <Tooltip label={tooltipContent} position={placement} withArrow multiline width={220}>
+      {children}
+    </Tooltip>
+  );
+};
+
+GameTooltip.propTypes = {
+  children: PropTypes.node.isRequired,
+  pieceName: PropTypes.string,
+  placement: PropTypes.oneOf(['top', 'bottom', 'left', 'right']),
+  showTooltips: PropTypes.bool, // new prop
+};
+
+export default GameTooltip;

--- a/src/components/GameTooltip/index.jsx
+++ b/src/components/GameTooltip/index.jsx
@@ -1,0 +1,1 @@
+export { default } from './GameTooltip';

--- a/src/components/HelpButton/HelpButton.jsx
+++ b/src/components/HelpButton/HelpButton.jsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+import { ActionIcon, Tooltip } from '@mantine/core';
+import { IconHelp } from '@tabler/icons-react';
+import Instructions from 'components/Instructions';
+import PropTypes from 'prop-types';
+
+const HelpButton = ({ gamePhase = 0, isEnglish = false, position = 'fixed' }) => {
+  const [instructionsOpened, setInstructionsOpened] = useState(false);
+
+  const buttonStyle = {
+    position,
+    bottom: '20px',
+    right: '20px',
+    zIndex: 1000,
+  };
+
+  return (
+    <>
+      <Tooltip label={isEnglish ? 'Game Instructions' : '遊戲說明'} position="left" withArrow>
+        <ActionIcon
+          size="xl"
+          radius="xl"
+          variant="filled"
+          color="blue"
+          onClick={() => setInstructionsOpened(true)}
+          style={buttonStyle}
+        >
+          <IconHelp size={24} />
+        </ActionIcon>
+      </Tooltip>
+
+      <Instructions
+        opened={instructionsOpened}
+        onClose={() => setInstructionsOpened(false)}
+        gamePhase={gamePhase}
+        isEnglish={isEnglish}
+      />
+    </>
+  );
+};
+
+HelpButton.propTypes = {
+  gamePhase: PropTypes.number,
+  isEnglish: PropTypes.bool,
+  position: PropTypes.oneOf(['fixed', 'absolute', 'relative']),
+};
+
+export default HelpButton;

--- a/src/components/HelpButton/index.jsx
+++ b/src/components/HelpButton/index.jsx
@@ -1,0 +1,1 @@
+export { default } from './HelpButton';

--- a/src/components/Instructions/Instructions.jsx
+++ b/src/components/Instructions/Instructions.jsx
@@ -1,0 +1,244 @@
+import React, { useState, useContext, useEffect } from 'react';
+import {
+  Modal,
+  Button,
+  Stack,
+  Title,
+  Text,
+  Group,
+  Box,
+  Stepper,
+  Card,
+  ThemeIcon,
+  Badge,
+  Divider,
+  Grid,
+  Alert,
+} from '@mantine/core';
+import {
+  IconQuestionMark,
+  IconChess,
+  IconTarget,
+  IconFlag,
+  IconBomb,
+  IconShield,
+  IconSword,
+  IconHelp,
+  IconUser,
+  IconChevronUp,
+  IconStar,
+  IconMedal,
+  IconCrown,
+  IconShieldStar,
+  IconSwords,
+  IconTrain,
+} from '@tabler/icons-react';
+import { GameContext } from 'contexts/GameContext';
+import pieceRules from 'data/pieceData.json';
+import PropTypes from 'prop-types';
+
+const iconMap = {
+  IconFlag: <IconFlag size={20} />,
+  IconBomb: <IconBomb size={20} />,
+  IconShield: <IconShield size={20} />,
+  IconSword: <IconSword size={20} />,
+  IconUser: <IconUser size={20} />,
+  IconChevronUp: <IconChevronUp size={20} />,
+  IconStar: <IconStar size={20} />,
+  IconMedal: <IconMedal size={20} />,
+  IconCrown: <IconCrown size={20} />,
+  IconShieldStar: <IconShieldStar size={20} />,
+  IconTarget: <IconTarget size={20} />,
+  IconSwords: <IconSwords size={20} />,
+  IconChess: <IconChess size={20} />,
+  IconTrain: <IconTrain size={20} />,
+};
+
+const Instructions = ({ opened, onClose, gamePhase = 0, isEnglish = false }) => {
+  const [activeStep, setActiveStep] = useState(0);
+
+  const getPhaseInstructions = () => {
+    switch (gamePhase) {
+      case 0:
+        return {
+          title: isEnglish ? 'How to Join a Game' : '如何加入遊戲',
+          steps: [
+            {
+              title: isEnglish ? 'Create or Join' : '創建或加入',
+              description: isEnglish
+                ? 'Either create a new game as host or join an existing game using a game ID.'
+                : '您可以創建新遊戲作為主持人，或使用遊戲ID加入現有遊戲。',
+            },
+            {
+              title: isEnglish ? 'Wait for Players' : '等待玩家',
+              description: isEnglish
+                ? 'Wait for another player to join. The host can start the game when ready.'
+                : '等待其他玩家加入。主持人準備好後可以開始遊戲。',
+            },
+            {
+              title: isEnglish ? 'Game Settings' : '遊戲設置',
+              description: isEnglish
+                ? 'Configure game options like fog of war before starting.'
+                : '在開始前配置遊戲選項，如戰爭迷霧。',
+            },
+          ],
+        };
+      case 1:
+        return {
+          title: isEnglish ? 'Setting Up Your Board' : '設置您的棋盤',
+          steps: [
+            {
+              title: isEnglish ? 'Drag and Drop Pieces' : '拖放棋子',
+              description: isEnglish
+                ? 'Drag pieces from the top area to your half of the board. Each piece has specific placement rules.'
+                : '將棋子從頂部區域拖放到您的半個棋盤上。每個棋子都有特定的放置規則。',
+            },
+            {
+              title: isEnglish ? 'Piece Placement Rules' : '棋子放置規則',
+              description: isEnglish
+                ? '• Flag must be in the back row\n• Bombs and landmines cannot be in the front row\n• All pieces must be placed'
+                : '• 軍旗必須在後排\n• 炸彈和地雷不能在前排\n• 所有棋子都必須放置',
+            },
+            {
+              title: isEnglish ? 'Submit Your Board' : '提交您的棋盤',
+              description: isEnglish
+                ? 'Click "Send Board Placement" when all pieces are placed correctly.'
+                : '當所有棋子都正確放置後，點擊「發送棋盤放置」。',
+            },
+          ],
+        };
+      case 2:
+        return {
+          title: isEnglish ? 'How to Play' : '如何遊戲',
+          steps: [
+            {
+              title: isEnglish ? 'Making Moves' : '移動棋子',
+              description: isEnglish
+                ? 'Click on your piece to select it, then click on a valid destination. Click "Send move" to confirm.'
+                : '點擊您的棋子選擇它，然後點擊有效目的地。點擊「發送移動」確認。',
+            },
+            {
+              title: isEnglish ? 'Piece Hierarchy' : '棋子階級',
+              description: isEnglish
+                ? 'Higher rank pieces capture lower rank pieces. Equal ranks result in both pieces being destroyed.'
+                : '高階棋子可以俘獲低階棋子。相同階級會導致兩個棋子都被摧毀。',
+            },
+            {
+              title: isEnglish ? 'Special Rules' : '特殊規則',
+              description: isEnglish
+                ? '• Engineer can safely defuse landmines\n• Bombs destroy any attacking piece\n• Flag capture wins the game'
+                : '• 工兵可以安全拆除地雷\n• 炸彈摧毀任何攻擊的棋子\n• 俘獲軍旗贏得遊戲',
+            },
+          ],
+        };
+      case 3:
+        return {
+          title: isEnglish ? 'Game Results' : '遊戲結果',
+          steps: [
+            {
+              title: isEnglish ? 'Victory Conditions' : '勝利條件',
+              description: isEnglish
+                ? "Capture the opponent's flag to win, or force them to forfeit."
+                : '俘獲對手的軍旗獲勝，或迫使他們投降。',
+            },
+            {
+              title: isEnglish ? 'Game Statistics' : '遊戲統計',
+              description: isEnglish
+                ? 'View remaining and lost pieces for both players.'
+                : '查看雙方玩家的剩餘和失去的棋子。',
+            },
+          ],
+        };
+      default:
+        return {
+          title: isEnglish ? 'Game Instructions' : '遊戲說明',
+          steps: [],
+        };
+    }
+  };
+
+  const renderPieceCard = (piece) => (
+    <Card key={piece.name} shadow="sm" padding="sm" radius="md" withBorder>
+      <Group style={{ flexDirection: 'row', flexWrap: 'nowrap' }}>
+        <ThemeIcon color="blue" variant="light" size={75}>
+          {iconMap[piece.icon] || <IconQuestionMark size={75} />}
+        </ThemeIcon>
+        <Box>
+          <Text fw={500}>{piece.name}</Text>
+          <Text size="sm" c="dimmed">
+            {piece.description}
+          </Text>
+          <Group gap="xs" mt="xs">
+            <Badge color={piece.canMove ? 'green' : 'red'} size="sm">
+              {piece.canMove ? 'Can Move' : 'Cannot Move'}
+            </Badge>
+            <Badge color={piece.canAttack ? 'green' : 'red'} size="sm">
+              {piece.canAttack ? 'Can Attack' : 'Cannot Attack'}
+            </Badge>
+          </Group>
+          {piece.special && (
+            <Text size="xs" c="blue" mt="xs">
+              {piece.special}
+            </Text>
+          )}
+        </Box>
+      </Group>
+    </Card>
+  );
+
+  const phaseInstructions = getPhaseInstructions();
+
+  return (
+    <Modal opened={opened} onClose={onClose} title={phaseInstructions.title} size="xl" centered>
+      <Stack>
+        <Stepper active={activeStep} onStepClick={setActiveStep} breakpoint="sm">
+          {phaseInstructions.steps.map((step, index) => (
+            <Stepper.Step key={index} label={step.title} description={step.description} />
+          ))}
+        </Stepper>
+
+        <Divider />
+
+        {gamePhase === 2 && (
+          <Box>
+            <Title order={4} mb="md">
+              {isEnglish ? 'Piece Reference' : '棋子參考'}
+            </Title>
+            <Grid>
+              {pieceRules.map((piece, index) => (
+                <Grid.Col span={6} key={`${piece.name}-${index}`}>
+                  {renderPieceCard(piece)}
+                </Grid.Col>
+              ))}
+            </Grid>
+          </Box>
+        )}
+
+        {gamePhase === 0 && (
+          <Alert icon={<IconHelp size={16} />} title="Quick Start" color="green">
+            <Text size="sm">
+              {isEnglish
+                ? 'Welcome to Luzhanqi! Create or join a game to start playing.'
+                : '歡迎來到陸戰棋！創建遊戲或與朋友一起加入開始遊戲。'}
+            </Text>
+          </Alert>
+        )}
+
+        <Group justify="right" mt="md">
+          <Button variant="outline" onClick={onClose}>
+            {isEnglish ? 'Close' : '關閉'}
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+};
+
+Instructions.propTypes = {
+  opened: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  gamePhase: PropTypes.number,
+  isEnglish: PropTypes.bool,
+};
+
+export default Instructions;

--- a/src/components/Instructions/index.jsx
+++ b/src/components/Instructions/index.jsx
@@ -1,0 +1,1 @@
+export { default } from './Instructions';

--- a/src/components/Position.jsx
+++ b/src/components/Position.jsx
@@ -156,7 +156,11 @@ export default function Position({
   return (
     <div ref={setNodeRef} className={`${row}-${col}`}>
       {/* TODO: only show overlay when something is being dragged */}
-      <Center mih="5em" bg={(!disabled && shadeColor) || 'transparent'}>
+      <Center
+        mih="5em"
+        bg={(!disabled && shadeColor) || 'transparent'}
+        sx={{ transition: 'background-color 1.5s ease-out' }}
+      >
         {getPositionContent()}
       </Center>
     </div>

--- a/src/components/SelectablePosition.jsx
+++ b/src/components/SelectablePosition.jsx
@@ -1,4 +1,5 @@
 import Position from './Position';
+import GameTooltip from 'components/GameTooltip';
 import { Box } from '@mantine/core';
 import { useHover } from '@mantine/hooks';
 import PropTypes from 'prop-types';
@@ -42,6 +43,7 @@ export default function SelectablePosition({
   movable = false,
   isEnglish,
   disabled = false,
+  gamePhase = 2,
 }) {
   const { hovered, ref } = useHover();
   const shadeColor = getShadeColor(
@@ -52,7 +54,7 @@ export default function SelectablePosition({
     movable
   );
 
-  return (
+  const positionContent = (
     <Box
       sx={{
         cursor: disabled ? 'not-allowed' : 'pointer',
@@ -71,6 +73,23 @@ export default function SelectablePosition({
       />
     </Box>
   );
+
+  // Only show tooltip for pieces, not empty spaces
+  if (piece && piece.name) {
+    return (
+      <GameTooltip
+        pieceName={piece.name}
+        gamePhase={gamePhase}
+        isEnglish={isEnglish}
+        placement="top"
+        disabled={disabled}
+      >
+        {positionContent}
+      </GameTooltip>
+    );
+  }
+
+  return positionContent;
 }
 
 SelectablePosition.propTypes = {
@@ -84,4 +103,5 @@ SelectablePosition.propTypes = {
   movable: PropTypes.bool.isRequired,
   isEnglish: PropTypes.bool.isRequired,
   disabled: PropTypes.bool.isRequired,
+  gamePhase: PropTypes.number,
 };

--- a/src/components/SelectablePosition.jsx
+++ b/src/components/SelectablePosition.jsx
@@ -9,9 +9,17 @@ const shadeMap = {
   destination: { color: 'orange.1', hover: 'orange.2' },
   attackable: { color: 'red.1', hover: 'red.2' },
   movable: { color: 'green.1', hover: 'green.2' },
+  lastMove: { color: 'yellow.2', hover: 'yellow.3' },
 };
 
-const getShadeColor = (hovered, originSelected, destinationSelected, attackable, movable) => {
+const getShadeColor = (
+  hovered,
+  originSelected,
+  destinationSelected,
+  attackable,
+  movable,
+  isLastMove
+) => {
   let state = null;
 
   if (originSelected) {
@@ -22,6 +30,8 @@ const getShadeColor = (hovered, originSelected, destinationSelected, attackable,
     state = 'attackable';
   } else if (movable) {
     state = 'movable';
+  } else if (isLastMove) {
+    state = 'lastMove';
   }
 
   if (!state) {
@@ -41,6 +51,7 @@ export default function SelectablePosition({
   destinationSelected = false,
   attackable = false,
   movable = false,
+  isLastMove = false,
   isEnglish,
   disabled = false,
   gamePhase = 2,
@@ -51,7 +62,8 @@ export default function SelectablePosition({
     originSelected,
     destinationSelected,
     attackable,
-    movable
+    movable,
+    isLastMove
   );
 
   const positionContent = (
@@ -101,6 +113,7 @@ SelectablePosition.propTypes = {
   destinationSelected: PropTypes.bool.isRequired,
   attackable: PropTypes.bool,
   movable: PropTypes.bool.isRequired,
+  isLastMove: PropTypes.bool,
   isEnglish: PropTypes.bool.isRequired,
   disabled: PropTypes.bool.isRequired,
   gamePhase: PropTypes.number,

--- a/src/contexts/GameContext.jsx
+++ b/src/contexts/GameContext.jsx
@@ -63,6 +63,9 @@ export const GameProvider = ({ children }) => {
   // eslint-disable-next-line no-unused-vars
   const [myBoard, setMyBoard] = useState(Array(12).fill(Array(5).fill(null)));
   const [myDeadPieces, setMyDeadPieces] = useState([]);
+  /** the most recent move's { source, target } coordinates (host-perspective,
+   * unrotated), or null before any move has been made */
+  const [lastMove, setLastMove] = useState(null);
   const [myPositions, setMyPositions] = useState(Array(6).fill(Array(5).fill(null)));
   const [submittedSide, setSubmittedSide] = useState(false);
   const [pendingMove, setPendingMove] = useState({
@@ -134,6 +137,7 @@ export const GameProvider = ({ children }) => {
     spectatorList: { spectatorList, setSpectatorList },
     myBoard: { myBoard, setMyBoard },
     myDeadPieces: { myDeadPieces, setMyDeadPieces },
+    lastMove: { lastMove, setLastMove },
     myPositions: { myPositions, setMyPositions },
     submittedSide: { submittedSide, setSubmittedSide },
     pendingMove: { pendingMove, setPendingMove },
@@ -213,6 +217,9 @@ export const GameProvider = ({ children }) => {
       setSubmittedSide(!!data.submittedSide);
       if (data.board) setMyBoard(data.board);
       if (Array.isArray(data.deadPieces)) setMyDeadPieces(data.deadPieces);
+      if (Array.isArray(data.moves) && data.moves.length) {
+        setLastMove(data.moves[data.moves.length - 1]);
+      }
       if (data.phase === 3) {
         setWinner(data.winnerIndex);
         if (data.gameStats) setGameResults(data.gameStats);
@@ -279,6 +286,7 @@ export const GameProvider = ({ children }) => {
     socket.on('boardSet', (game) => {
       setMyBoard(game.board);
       setGamePhase(2);
+      setLastMove(null);
       // normally set by beginNewGame, but that event never fires for AI
       // games since they skip the Lobby's "Room Full" step entirely
       if (typeof game.turn === 'number') setClientTurn(game.turn);
@@ -293,10 +301,13 @@ export const GameProvider = ({ children }) => {
     });
 
     /** Server is telling all clients a move has been made */
-    socket.on('playerMadeMove', ({ turn, board, deadPieces }) => {
+    socket.on('playerMadeMove', ({ turn, board, deadPieces, moves }) => {
       setClientTurn(turn);
       setMyBoard(board);
       setMyDeadPieces(deadPieces);
+      if (Array.isArray(moves) && moves.length) {
+        setLastMove(moves[moves.length - 1]);
+      }
     });
 
     /** Server is telling all clients the game has ended */

--- a/src/contexts/GameContext.jsx
+++ b/src/contexts/GameContext.jsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState, useEffect } from 'react';
+import React, { createContext, useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router';
 import { io } from 'socket.io-client';
 import { uniqueNamesGenerator, colors, animals } from 'unique-names-generator';
@@ -10,6 +10,26 @@ const socket = io(import.meta.env.VITE_API);
 
 export const GameContext = createContext({});
 
+const sessionKey = (gameId) => `luzhanqi:session:${gameId}`;
+
+const saveSession = (gameId, name, token) => {
+  if (!gameId || !token) return;
+  window.localStorage.setItem(sessionKey(gameId), JSON.stringify({ playerName: name, token }));
+};
+
+const loadSession = (gameId) => {
+  try {
+    const raw = window.localStorage.getItem(sessionKey(gameId));
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+};
+
+const clearSession = (gameId) => {
+  window.localStorage.removeItem(sessionKey(gameId));
+};
+
 export const GameProvider = ({ children }) => {
   const navigate = useNavigate();
 
@@ -19,6 +39,13 @@ export const GameProvider = ({ children }) => {
     length: 2,
   });
   const [playerName, setPlayerName] = useState(defaultName);
+  // socket handlers below are registered in an effect that doesn't
+  // re-run on every playerName change (see its dependency array) - this
+  // ref lets them always read the latest name instead of a stale closure
+  const playerNameRef = useRef(playerName);
+  useEffect(() => {
+    playerNameRef.current = playerName;
+  }, [playerName]);
   const [spectatorName, setSpectatorName] = useState(defaultName);
   /** game ID assigned to host, or user-input: game Id entered by player */
   const [roomId, setRoomId] = useState('');
@@ -69,6 +96,29 @@ export const GameProvider = ({ children }) => {
 
   const [errors, setErrors] = useState([]);
 
+  /** whether a silent rejoin attempt is in flight for the current game ID */
+  const [rejoining, setRejoining] = useState(false);
+  /** name of the opponent whose socket most recently disconnected, or null */
+  const [disconnectedPlayer, setDisconnectedPlayer] = useState(null);
+
+  /** Attempts to silently reclaim a seat using a locally-stored session token. Returns
+   * false immediately if no stored session exists for this game ID. */
+  const attemptRejoin = (gameId) => {
+    const session = loadSession(gameId);
+    if (!session) {
+      setRejoining(false);
+      return false;
+    }
+    setRejoining(true);
+    setPlayerName(session.playerName);
+    socket.emit('playerRejoinRoom', {
+      gameId,
+      playerName: session.playerName,
+      token: session.token,
+    });
+    return true;
+  };
+
   const gameState = {
     socket,
     playerName: { playerName, setPlayerName },
@@ -94,6 +144,9 @@ export const GameProvider = ({ children }) => {
     gameResults: { gameResults, setGameResults },
     isEnglish: { isEnglish, setIsEnglish },
     errors: { errors, setErrors },
+    rejoining: { rejoining, setRejoining },
+    disconnectedPlayer: { disconnectedPlayer, setDisconnectedPlayer },
+    attemptRejoin,
   };
 
   // extend error (list of errors) to include new errors
@@ -112,11 +165,13 @@ export const GameProvider = ({ children }) => {
     });
 
     /** Server has created a new game, only host receives this message */
-    socket.on('newGameCreated', ({ gameId, mySocketId, players }) => {
+    socket.on('newGameCreated', ({ gameId, mySocketId, players, phase, token }) => {
       const serverRoomId = gameId;
       console.info(`GameID: ${serverRoomId}, SocketID: ${mySocketId}`);
       setRoomId(serverRoomId);
       setPlayerList(players);
+      saveSession(serverRoomId, playerNameRef.current, token);
+      if (typeof phase === 'number') setGamePhase(phase);
       navigate(`/game/${serverRoomId}`);
     });
 
@@ -139,11 +194,46 @@ export const GameProvider = ({ children }) => {
     socket.on('youHaveJoinedTheRoom', (data) => {
       setJoinedGame(true);
       // setPlayerList(data.players);
-      navigate(`/game/${roomId}`);
-      window.sessionStorage.setItem('playerName', playerName);
-      window.sessionStorage.setItem('roomId', roomId);
-      window.sessionStorage.setItem('playerList', data.players);
+      const joinedRoomId = data.joinRoomId || roomId;
+      navigate(`/game/${joinedRoomId}`);
+      saveSession(joinedRoomId, playerNameRef.current, data.token);
+      if (typeof data.phase === 'number') setGamePhase(data.phase);
       if (Array.isArray(data.spectators)) setSpectatorList(data.spectators);
+    });
+
+    /** A stored session successfully reclaimed a seat after a disconnect/reload */
+    socket.on('youHaveRejoinedTheRoom', (data) => {
+      setRejoining(false);
+      setJoinedGame(true);
+      setPlayerList(data.players || []);
+      setSpectatorList(data.spectators || []);
+      setHost(data.players?.[0] === data.playerName);
+      setClientTurn(typeof data.turn === 'number' ? data.turn : -1);
+      setGamePhase(typeof data.phase === 'number' ? data.phase : 0);
+      setSubmittedSide(!!data.submittedSide);
+      if (data.board) setMyBoard(data.board);
+      if (Array.isArray(data.deadPieces)) setMyDeadPieces(data.deadPieces);
+      if (data.phase === 3) {
+        setWinner(data.winnerIndex);
+        if (data.gameStats) setGameResults(data.gameStats);
+      }
+      setRoomId(data.gameId);
+      navigate(`/game/${data.gameId}`);
+    });
+
+    /** The stored session token was rejected - fall back to the normal join form */
+    socket.on('rejoinFailed', (data) => {
+      setRejoining(false);
+      clearSession(data.gameId);
+    });
+
+    /** An opponent's socket dropped - their seat is still reserved, they may reconnect */
+    socket.on('playerDisconnected', ({ playerName: droppedName }) => {
+      setDisconnectedPlayer(droppedName);
+    });
+
+    socket.on('playerReconnected', ({ playerName: returnedName }) => {
+      setDisconnectedPlayer((current) => (current === returnedName ? null : current));
     });
 
     socket.on('playerLeftRoom', ({ playerName: returnedPlayerName, players }) => {
@@ -189,6 +279,9 @@ export const GameProvider = ({ children }) => {
     socket.on('boardSet', (game) => {
       setMyBoard(game.board);
       setGamePhase(2);
+      // normally set by beginNewGame, but that event never fires for AI
+      // games since they skip the Lobby's "Room Full" step entirely
+      if (typeof game.turn === 'number') setClientTurn(game.turn);
     });
 
     socket.on('halfBoardReceived', () => {

--- a/src/data/pieceData.json
+++ b/src/data/pieceData.json
@@ -1,0 +1,94 @@
+[
+    {
+      "id": "flag",
+      "icon": "IconFlag",
+      "title": "Flag",
+      "description": "The most important piece. If captured, you lose the game.",
+      "rules": ["Cannot move", "Cannot attack", "Must be protected at all costs"]
+    },
+    {
+      "id": "landmine",
+      "icon": "IconShieldHalfFilled",
+      "title": "Landmine",
+      "description": "Hidden explosive. Only Engineer can defuse safely.",
+      "rules": ["Cannot move", "Cannot attack", "Only Engineer can capture safely"]
+    },
+    {
+      "id": "bomb",
+      "icon": "IconBomb",
+      "title": "Bomb",
+      "description": "Explodes when attacked. Both pieces destroyed.",
+      "rules": ["Cannot move", "Cannot attack", "Destroys any attacker except Engineer"]
+    },
+    {
+      "id": "engineer",
+      "icon": "IconTool",
+      "title": "Engineer",
+      "description": "Can safely defuse landmines and bombs.",
+      "rules": ["Can move", "Can attack", "Only piece that can capture landmines safely"]
+    },
+    {
+      "id": "sergeant",
+      "icon": "IconUserCircle",
+      "title": "Sergeant",
+      "description": "Low-ranking NCO with basic combat abilities.",
+      "rules": ["Can move", "Can attack", "Rank 2"]
+    },
+    {
+      "id": "lieutenant",
+      "icon": "IconUser",
+      "title": "Lieutenant",
+      "description": "Junior officer commanding small units.",
+      "rules": ["Can move", "Can attack", "Rank 3"]
+    },
+    {
+      "id": "captain",
+      "icon": "IconUserShield",
+      "title": "Captain",
+      "description": "Commands a company; strong leadership.",
+      "rules": ["Can move", "Can attack", "Rank 4"]
+    },
+    {
+      "id": "major",
+      "icon": "IconChevronUp",
+      "title": "Major",
+      "description": "Mid-level field officer.",
+      "rules": ["Can move", "Can attack", "Rank 5"]
+    },
+    {
+      "id": "colonel",
+      "icon": "IconBadge",
+      "title": "Colonel",
+      "description": "Senior officer commanding regiments.",
+      "rules": ["Can move", "Can attack", "Rank 6"]
+    },
+    {
+      "id": "brigadier_general",
+      "icon": "IconStar",
+      "title": "Brigadier General",
+      "description": "Commands a brigade.",
+      "rules": ["Can move", "Can attack", "Rank 7"]
+    },
+    {
+      "id": "major_general",
+      "icon": "IconMedal",
+      "title": "Major General",
+      "description": "High-ranking general, decorated for leadership.",
+      "rules": ["Can move", "Can attack", "Rank 8"]
+    },
+    {
+      "id": "general",
+      "icon": "IconShieldStar",
+      "title": "General",
+      "description": "Senior general officer commanding corps-level forces.",
+      "rules": ["Can move", "Can attack", "Rank 9"]
+    },
+    {
+      "id": "field_marshall",
+      "icon": "IconCrown",
+      "title": "Field Marshal",
+      "description": "Supreme commander of all forces.",
+      "rules": ["Can move", "Can attack", "Highest rank (10)"]
+    }
+  ]
+  

--- a/src/views/Game.jsx
+++ b/src/views/Game.jsx
@@ -8,6 +8,7 @@ import Menu from './Menu';
 import BoardSetup from 'components/BoardSetup';
 import GameOver from 'components/GameOver';
 import GameBoard from 'components/GameBoard';
+import HelpButton from 'components/HelpButton';
 import { useFirebaseAuth } from 'contexts/FirebaseContext';
 import { Container, Flex, Center, Button, CopyButton, Title } from '@mantine/core';
 
@@ -177,6 +178,7 @@ const Game = () => {
           ) : null
         }
       </Container>
+      <HelpButton gamePhase={gamePhase} isEnglish={isEnglish} />
       <ToastContainer />
     </>
   );

--- a/src/views/Game.jsx
+++ b/src/views/Game.jsx
@@ -10,7 +10,7 @@ import GameOver from 'components/GameOver';
 import GameBoard from 'components/GameBoard';
 import HelpButton from 'components/HelpButton';
 import { useFirebaseAuth } from 'contexts/FirebaseContext';
-import { Container, Flex, Center, Button, CopyButton, Title } from '@mantine/core';
+import { Container, Flex, Center, Button, CopyButton, Title, Loader } from '@mantine/core';
 
 const Game = () => {
   let { roomId } = useParams();
@@ -28,9 +28,22 @@ const Game = () => {
     myBoard: { myBoard },
     myDeadPieces: { myDeadPieces },
     isEnglish: { isEnglish },
+    joinedGame: { joinedGame },
+    rejoining: { rejoining },
+    disconnectedPlayer: { disconnectedPlayer },
+    attemptRejoin,
   } = useContext(GameContext);
 
   const affiliation = playerList.indexOf(playerName);
+
+  /** On mount (or a hard reload), silently try to reclaim a seat using a
+   * locally-stored session before falling back to the normal join form. */
+  useEffect(() => {
+    if (roomId && !joinedGame && playerList.length === 0) {
+      attemptRejoin(roomId);
+    }
+    // only re-run when the room in the URL changes, not on every state update
+  }, [roomId]);
 
   /** Clear errors after 1 second each */
   useEffect(() => {
@@ -143,7 +156,21 @@ const Game = () => {
           </Container>
         ) : null}
 
-        {playerList.length ? null : <Menu joinedRoom={true} urlRoomId={roomId} />}
+        {disconnectedPlayer ? (
+          <Center>
+            <Title order={4}>
+              {disconnectedPlayer} disconnected — waiting for them to reconnect…
+            </Title>
+          </Center>
+        ) : null}
+
+        {playerList.length ? null : rejoining ? (
+          <Center style={{ padding: '2em' }}>
+            <Loader />
+          </Center>
+        ) : (
+          <Menu joinedRoom={true} urlRoomId={roomId} />
+        )}
         <br />
         {
           /** Players join the game */

--- a/src/views/Game.jsx
+++ b/src/views/Game.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { useParams } from 'react-router';
 import { GameContext } from 'contexts/GameContext';
 import { ToastContainer, toast } from 'react-toastify';
@@ -27,6 +27,7 @@ const Game = () => {
     errors: { errors, setErrors },
     myBoard: { myBoard },
     myDeadPieces: { myDeadPieces },
+    lastMove: { lastMove },
     isEnglish: { isEnglish },
     joinedGame: { joinedGame },
     rejoining: { rejoining },
@@ -35,6 +36,19 @@ const Game = () => {
   } = useContext(GameContext);
 
   const affiliation = playerList.indexOf(playerName);
+
+  /** Show the last move highlight immediately, then let it fade after a
+   * few seconds so it doesn't linger and clutter the board. */
+  const [lastMoveVisible, setLastMoveVisible] = useState(false);
+  useEffect(() => {
+    if (!lastMove) {
+      setLastMoveVisible(false);
+      return undefined;
+    }
+    setLastMoveVisible(true);
+    const timer = setTimeout(() => setLastMoveVisible(false), 2000);
+    return () => clearTimeout(timer);
+  }, [lastMove]);
 
   /** On mount (or a hard reload), silently try to reclaim a seat using a
    * locally-stored session before falling back to the normal join form. */
@@ -58,6 +72,16 @@ const Game = () => {
   const rotateMove = ([row, col]) => {
     return [11 - row, 4 - col];
   };
+
+  // last move coordinates are always stored host-perspective; rotate for
+  // display the same way the board itself is rotated for the guest
+  const displayLastMove =
+    lastMoveVisible && lastMove
+      ? {
+          source: host ? lastMove.source : rotateMove(lastMove.source),
+          target: host ? lastMove.target : rotateMove(lastMove.target),
+        }
+      : null;
 
   const playerMakeMove = (source, target, host) => {
     if (source.length && target.length) {
@@ -201,6 +225,7 @@ const Game = () => {
               isEnglish={isEnglish}
               isSpectator={spectatorList.includes(spectatorName)}
               gamePhase={gamePhase}
+              lastMove={displayLastMove}
             />
           ) : null
         }

--- a/src/views/Menu.jsx
+++ b/src/views/Menu.jsx
@@ -7,6 +7,7 @@ import { Button, Container, TextInput } from '@mantine/core';
 import { useFirebaseAuth } from 'contexts/FirebaseContext';
 import { useForm } from '@mantine/form';
 import { Title } from '@mantine/core';
+import HelpButton from '../components/HelpButton';
 
 function Menu({ joinedRoom = false, urlRoomId = '' }) {
   const {
@@ -16,6 +17,7 @@ function Menu({ joinedRoom = false, urlRoomId = '' }) {
     roomId: { setRoomId },
     host: { setHost },
     errors: { errors, setErrors },
+    isEnglish: { isEnglish },
   } = useContext(GameContext);
 
   const user = useFirebaseAuth();
@@ -232,6 +234,7 @@ function Menu({ joinedRoom = false, urlRoomId = '' }) {
           </Container>
         </Container>
       </Container>
+      <HelpButton gamePhase={0} isEnglish={isEnglish} />
       <ToastContainer />
     </>
   );

--- a/src/views/Menu.jsx
+++ b/src/views/Menu.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { GameContext } from 'contexts/GameContext';
 import { Link } from 'react-router-dom';
 import { ToastContainer, toast } from 'react-toastify';
-import { Button, Container, TextInput } from '@mantine/core';
+import { Button, Checkbox, Container, TextInput } from '@mantine/core';
 import { useFirebaseAuth } from 'contexts/FirebaseContext';
 import { useForm } from '@mantine/form';
 import { Title } from '@mantine/core';
@@ -12,7 +12,7 @@ import HelpButton from '../components/HelpButton';
 function Menu({ joinedRoom = false, urlRoomId = '' }) {
   const {
     socket,
-    playerName: { playerName },
+    playerName: { playerName, setPlayerName },
     spectatorName: { spectatorName },
     roomId: { setRoomId },
     host: { setHost },
@@ -63,9 +63,14 @@ function Menu({ joinedRoom = false, urlRoomId = '' }) {
   const linkStyle = { color: 'white' };
 
   /** Tell the server to create a new game */
-  const createNewGame = (name) => {
+  const createNewGame = (name, vsAi) => {
     if (name) {
-      socket.emit('hostCreateNewGame', { playerName: name, hostId: user?.uid || null });
+      setPlayerName(name);
+      socket.emit('hostCreateNewGame', {
+        playerName: name,
+        hostId: user?.uid || null,
+        gameConfig: vsAi ? { opponentType: 'ai' } : undefined,
+      });
       setHost(true);
       // GameContext will redirect to /game when socket starts the game
     } else {
@@ -74,11 +79,12 @@ function Menu({ joinedRoom = false, urlRoomId = '' }) {
   };
 
   /** Attempt to join a room by game ID */
-  const playerJoinGame = (playerName, roomId) => {
-    if (playerName && roomId) {
-      console.info(`Attempting to JOIN game ${roomId} as ${playerName} with clientId ${user?.uid}`);
+  const playerJoinGame = (name, roomId) => {
+    if (name && roomId) {
+      console.info(`Attempting to JOIN game ${roomId} as ${name} with clientId ${user?.uid}`);
+      setPlayerName(name);
       socket.emit('playerJoinRoom', {
-        playerName,
+        playerName: name,
         clientId: user?.uid || null,
         joinRoomId: roomId,
       });
@@ -111,8 +117,8 @@ function Menu({ joinedRoom = false, urlRoomId = '' }) {
     }
   };
 
-  const handleCreateSubmit = ({ playerName }) => {
-    createNewGame(playerName);
+  const handleCreateSubmit = ({ playerName, vsAi }) => {
+    createNewGame(playerName, vsAi);
   };
 
   const handleJoinSubmit = ({ playerName, roomId }) => {
@@ -125,7 +131,7 @@ function Menu({ joinedRoom = false, urlRoomId = '' }) {
 
   const CreateForm = () => {
     const createForm = useForm({
-      initialValues: { playerName },
+      initialValues: { playerName, vsAi: false },
     });
 
     return (
@@ -136,6 +142,11 @@ function Menu({ joinedRoom = false, urlRoomId = '' }) {
             label="Player name:"
             placeholder="Ex. Ian"
             {...createForm.getInputProps('playerName')}
+          />
+          <Checkbox
+            mt="md"
+            label="Play against the computer"
+            {...createForm.getInputProps('vsAi', { type: 'checkbox' })}
           />
           <br />
           <Button variant="info" type="submit">

--- a/vite.config.js
+++ b/vite.config.js
@@ -14,6 +14,7 @@ export default defineConfig(() => {
         api: path.resolve(__dirname, './src/api'),
         hooks: path.resolve(__dirname, './src/hooks'),
         utils: path.resolve(__dirname, './src/utils'),
+        data: path.resolve(__dirname, './src/data'),
       },
     },
 


### PR DESCRIPTION
## Summary
Pairs with the backend PR: chinese-board-games/luzhanqi-backend#65

- `GameContext` persists a per-seat reconnection token to `localStorage` (keyed by game ID) and silently retries joining via a new `playerRejoinRoom` event when `Game.jsx` mounts with an empty player list - closing the browser or reloading no longer permanently loses your seat. Also surfaces a lightweight "opponent disconnected" banner.
- `Menu.jsx` gets a "Play against the computer" checkbox that creates a game with `opponentType: 'ai'`, which the backend uses to skip the waiting-room Lobby and go straight to piece placement.
- Fixes a stale-closure bug where the socket handlers registered in `GameContext`'s effect (which only re-runs on `roomId`/`errors` changes) could save the wrong player name to `localStorage` if the player edited their name in the join/create form.

## Test plan
- [x] `npm run build` (vite) and `npm run lint`
- [x] Verified live end-to-end against a local backend (see backend PR for details): vs-AI game skips the Lobby and reaches gameplay with the AI's pieces properly hidden; a guest's reload silently rejoins instead of losing their seat
- [ ] Manual follow-up: full mid-game reconnection and a full played-out vs-AI match

🤖 Generated with [Claude Code](https://claude.com/claude-code)