### PR TITLE
fix: board overflowing horizontally on narrow phones

### DIFF
--- a/src/components/BoardSetup/HalfBoard.jsx
+++ b/src/components/BoardSetup/HalfBoard.jsx
@@ -193,7 +193,20 @@ export default function HalfBoard({ sendStartingBoard, playerList, playerName, i
   };
 
   return (
-    <Container bg="#e0e0e0" maw="46em" p="1em 2em">
+    <Container
+      bg="#e0e0e0"
+      maw="46em"
+      sx={{
+        padding: '1em 2em',
+        overflowX: 'auto',
+        '@media (max-width: 450px)': {
+          padding: '1em 0.5em',
+        },
+        '@media (max-width: 375px)': {
+          padding: '0.75em 0.25em',
+        },
+      }}
+    >
       <HalfBoardConnectionLines />
       <DndContext
         autoScroll={false}
@@ -239,7 +252,7 @@ export default function HalfBoard({ sendStartingBoard, playerList, playerName, i
           <Box sx={{ position: 'sticky', top: 0, zIndex: 110 }}>
             <PieceSelector unplacedPieces={unplacedPieces} isEnglish={isEnglish} />
           </Box>
-          <Grid columns={20}>
+          <Grid columns={20} gutter={6}>
             {halfBoard.flatMap((row, r) =>
               row.map((piece, c) => (
                 // eslint-disable-next-line react/no-array-index-key

--- a/src/components/GameBoard/index.jsx
+++ b/src/components/GameBoard/index.jsx
@@ -132,7 +132,21 @@ export default function GameBoard({
 
   return (
     <>
-      <Container bg="rgb(224, 224, 224)" sx={{ borderRadius: '1em' }} p="1em 2em" maw="40em">
+      <Container
+        bg="rgb(224, 224, 224)"
+        maw="40em"
+        sx={{
+          borderRadius: '1em',
+          padding: '1em 2em',
+          overflowX: 'auto',
+          '@media (max-width: 450px)': {
+            padding: '1em 0.5em',
+          },
+          '@media (max-width: 375px)': {
+            padding: '0.75em 0.25em',
+          },
+        }}
+      >
         {isSpectator || gamePhase > 2 ? null : (
           <Center py="1em">
             <Stack>
@@ -166,7 +180,9 @@ export default function GameBoard({
         )}
 
         <ConnectionLines />
-        <Grid columns={20}>{combined.map((cell) => cell)}</Grid>
+        <Grid columns={20} gutter={6}>
+          {combined.map((cell) => cell)}
+        </Grid>
       </Container>
       <DeadPieces deadPieces={deadPieces} isEnglish={isEnglish} />
     </>

--- a/src/components/Position.jsx
+++ b/src/components/Position.jsx
@@ -67,6 +67,11 @@ export default function Position({
               height: theme.other.campSizing.sm.height,
               fontSize: theme.other.campSizing.sm.fontSize,
             },
+            '@media (max-width: 375px)': {
+              width: theme.other.campSizing.xs.width,
+              height: theme.other.campSizing.xs.height,
+              fontSize: theme.other.campSizing.xs.fontSize,
+            },
           })}
         >
           {placedPiece || '行營'}

--- a/src/theme.js
+++ b/src/theme.js
@@ -79,6 +79,11 @@ export const other = {
       height: '3.5em',
       fontSize: '12pt',
     },
+    xs: {
+      width: '3em',
+      height: '3em',
+      fontSize: '10pt',
+    },
   },
   fontLinesSizing: {
     md: {

--- a/src/views/Game.jsx
+++ b/src/views/Game.jsx
@@ -123,7 +123,18 @@ const Game = () => {
 
   return (
     <>
-      <Container style={{ minWidth: '23em', width: '90%' }}>
+      <Container
+        sx={{
+          width: '90%',
+          minWidth: '23em',
+          // 23em (368px) forces horizontal overflow on phones narrower than
+          // that - drop the minimum and use the full width instead
+          '@media (max-width: 450px)': {
+            width: '100%',
+            minWidth: 'unset',
+          },
+        }}
+      >
         {roomId ? (
           <Container>
             {/* if the playerList is empty, the user must have gotten here via a urlRoomId */}


### PR DESCRIPTION
## Summary
Not actually an animation bug - the piece-placement and last-move animations were just playing out inside a board that was already too wide for the screen. On a 320px-wide phone the page rendered ~369px wide (a ~49px overflow), mostly from:

- `Game.jsx`'s page container had a fixed `minWidth: 23em` (368px), which alone accounts for nearly the entire overflow on the smallest screens - it now drops to 100% width below 450px instead of 90% + a hard minimum.
- `campSizing` (the round camp tiles) had no `xs` breakpoint in `theme.js`, so those tiles stayed at their 450px-breakpoint size while every other tile kept shrinking below that, throwing off row alignment.
- The board's outer padding and grid gutter were fixed regardless of viewport width; both now shrink at the existing 450px/375px breakpoints, and the board containers gained `overflow-x: auto` as a safety net so any residual overflow scrolls locally instead of dragging the whole page sideways.

## Test plan
- [x] `npm run build` and `npm run lint` (repo-wide, clean)
- [x] Verified live at a 320px viewport (Playwright + iPhone SE device profile): overflow went from 49px down to ~1px (rounding noise) on both the board-setup and gameplay screens - screenshots below

| Before | After |
|---|---|
| 369px wide, ~49px overflow | 321px wide, ~1px |