### PR TITLE
feat(gameboard): replace piece hover tooltip with a desktop info panel

### DIFF
--- a/src/components/GameBoard/index.jsx
+++ b/src/components/GameBoard/index.jsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react';
-import { Grid, Container, Center, Stack, Button, Group } from '@mantine/core';
+import { Grid, Container, Center, Stack, Button, Group, Flex } from '@mantine/core';
 import { emptyBoard } from 'utils/core';
 import SelectablePosition from '../SelectablePosition';
+import PieceInfoPanel from '../PieceInfoPanel';
 import { isEqual } from 'lodash';
 import FrontLines from './FrontLines';
 import Mountain from './Mountain';
@@ -9,8 +10,13 @@ import ConnectionLines from './ConnectionLines';
 import DeadPieces from './DeadPieces';
 import PropTypes from 'prop-types';
 import { getSuccessors } from 'utils';
+import useWindowSize from 'hooks/useWindowSize';
 
 const NO_SELECT = [-1, -1];
+// the info panel needs real estate beside the board - below this width
+// there's no room for it, and it's a hover-driven feature that doesn't
+// translate to touch devices anyway
+const DESKTOP_PANEL_BREAKPOINT = 900;
 
 export default function GameBoard({
   host,
@@ -27,10 +33,16 @@ export default function GameBoard({
 }) {
   const [origin, setOrigin] = useState(NO_SELECT);
   const [destination, setDestination] = useState(NO_SELECT);
+  const [hoveredPiece, setHoveredPiece] = useState(null);
+  const [width] = useWindowSize();
+  const showInfoPanel = width >= DESKTOP_PANEL_BREAKPOINT;
 
   const originSelected = !isEqual(origin, NO_SELECT);
   const destinationSelected = !isEqual(destination, NO_SELECT);
   const nothingSelected = !originSelected && !destinationSelected;
+
+  const originPiece = originSelected ? board[origin[0]][origin[1]] : null;
+  const destinationPiece = destinationSelected ? board[destination[0]][destination[1]] : null;
 
   const moves = originSelected ? getSuccessors(board, origin[0], origin[1], affiliation) : [];
   const availibleMoves = new Set(moves.map((move) => JSON.stringify(move)));
@@ -106,7 +118,7 @@ export default function GameBoard({
           }}
           isEnglish={isEnglish}
           disabled={positionDisabled(r, c)}
-          gamePhase={gamePhase}
+          onHoverPiece={setHoveredPiece}
         />
       </Grid.Col>
     ))
@@ -132,58 +144,67 @@ export default function GameBoard({
 
   return (
     <>
-      <Container
-        bg="rgb(224, 224, 224)"
-        maw="40em"
-        sx={{
-          borderRadius: '1em',
-          padding: '1em 2em',
-          overflowX: 'auto',
-          '@media (max-width: 450px)': {
-            padding: '1em 0.5em',
-          },
-          '@media (max-width: 375px)': {
-            padding: '0.75em 0.25em',
-          },
-        }}
-      >
-        {isSpectator || gamePhase > 2 ? null : (
-          <Center py="1em">
-            <Stack>
-              <Group align="center" direction="horizontal">
-                <Button
-                  disabled={!isTurn || !(originSelected && destinationSelected)}
-                  onClick={() => {
-                    sendMove(origin, destination, host);
-                    setOrigin(NO_SELECT);
-                    setDestination(NO_SELECT);
-                  }}
-                >
-                  {isTurn ? 'Send move' : 'Opponent turn'}
-                </Button>
-                <Button
-                  variant="outline"
-                  color="red"
-                  onClick={() => {
-                    setOrigin(NO_SELECT);
-                    setDestination(NO_SELECT);
-                  }}
-                >
-                  Reset move
-                </Button>
-                <Button variant="filled" color="red" onClick={forfeit}>
-                  Forfeit
-                </Button>
-              </Group>
-            </Stack>
-          </Center>
-        )}
+      <Flex gap="1em" justify="center" wrap="wrap" align="flex-start">
+        <Container
+          bg="rgb(224, 224, 224)"
+          maw="40em"
+          sx={{
+            borderRadius: '1em',
+            padding: '1em 2em',
+            overflowX: 'auto',
+            '@media (max-width: 450px)': {
+              padding: '1em 0.5em',
+            },
+            '@media (max-width: 375px)': {
+              padding: '0.75em 0.25em',
+            },
+          }}
+        >
+          {isSpectator || gamePhase > 2 ? null : (
+            <Center py="1em">
+              <Stack>
+                <Group align="center" direction="horizontal">
+                  <Button
+                    disabled={!isTurn || !(originSelected && destinationSelected)}
+                    onClick={() => {
+                      sendMove(origin, destination, host);
+                      setOrigin(NO_SELECT);
+                      setDestination(NO_SELECT);
+                    }}
+                  >
+                    {isTurn ? 'Send move' : 'Opponent turn'}
+                  </Button>
+                  <Button
+                    variant="outline"
+                    color="red"
+                    onClick={() => {
+                      setOrigin(NO_SELECT);
+                      setDestination(NO_SELECT);
+                    }}
+                  >
+                    Reset move
+                  </Button>
+                  <Button variant="filled" color="red" onClick={forfeit}>
+                    Forfeit
+                  </Button>
+                </Group>
+              </Stack>
+            </Center>
+          )}
 
-        <ConnectionLines />
-        <Grid columns={20} gutter={6}>
-          {combined.map((cell) => cell)}
-        </Grid>
-      </Container>
+          <ConnectionLines />
+          <Grid columns={20} gutter={6}>
+            {combined.map((cell) => cell)}
+          </Grid>
+        </Container>
+        {showInfoPanel ? (
+          <PieceInfoPanel
+            hoveredPiece={hoveredPiece}
+            originPiece={originPiece}
+            destinationPiece={destinationPiece}
+          />
+        ) : null}
+      </Flex>
       <DeadPieces deadPieces={deadPieces} isEnglish={isEnglish} />
     </>
   );

--- a/src/components/GameTooltip/GameTooltip.jsx
+++ b/src/components/GameTooltip/GameTooltip.jsx
@@ -2,36 +2,7 @@ import React from 'react';
 import { Tooltip, Text, Box, List, ThemeIcon } from '@mantine/core';
 import { IconInfoCircle } from '@tabler/icons-react';
 import PropTypes from 'prop-types';
-import pieceData from '../../data/pieceData.json';
-
-// map string names from JSON → actual icon components
-import * as Icons from '@tabler/icons-react';
-
-const iconMap = {
-  IconFlag: Icons.IconFlag,
-  IconBomb: Icons.IconBomb,
-  IconShieldHalfFilled: Icons.IconShieldHalfFilled,
-  IconTool: Icons.IconTool,
-  IconUserCircle: Icons.IconUserCircle,
-  IconUser: Icons.IconUser,
-  IconUserShield: Icons.IconUserShield,
-  IconChevronUp: Icons.IconChevronUp,
-  IconBadge: Icons.IconBadge,
-  IconStar: Icons.IconStar,
-  IconMedal: Icons.IconMedal,
-  IconShieldStar: Icons.IconShieldStar,
-  IconCrown: Icons.IconCrown,
-};
-
-const pieceInfo = Object.fromEntries(
-  pieceData.map((piece) => [
-    piece.id,
-    {
-      ...piece,
-      icon: React.createElement(iconMap[piece.icon] || Icons.IconQuestionMark, { size: 16 }),
-    },
-  ])
-);
+import pieceInfo from 'data/pieceInfo';
 
 const GameTooltip = ({
   children,

--- a/src/components/PieceInfoPanel/PieceInfoPanel.jsx
+++ b/src/components/PieceInfoPanel/PieceInfoPanel.jsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { Box, Text, List, ThemeIcon, Stack, Divider } from '@mantine/core';
+import { IconInfoCircle } from '@tabler/icons-react';
+import PropTypes from 'prop-types';
+import pieceInfo from 'data/pieceInfo';
+import { predictOutcome } from 'utils/predictOutcome';
+
+const outcomeMessages = {
+  'both-die': { color: 'red', text: 'Both pieces will be destroyed.' },
+  'target-dies': { color: 'green', text: 'The enemy piece will be destroyed.' },
+  'source-dies': { color: 'red', text: 'Your piece will be destroyed.' },
+  unknown: {
+    color: 'gray',
+    text: "This piece's identity is hidden — the outcome can't be predicted.",
+  },
+};
+
+function PieceCard({ piece }) {
+  const info = pieceInfo[piece.name];
+  if (!info) {
+    return null;
+  }
+  return (
+    <Stack spacing={4}>
+      <Box style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <ThemeIcon color="blue" variant="light" size="sm">
+          {info.icon}
+        </ThemeIcon>
+        <Text fw={600} size="sm">
+          {info.title}
+        </Text>
+      </Box>
+      <Text size="xs" c="dimmed">
+        {info.description}
+      </Text>
+      <List size="xs" spacing={4}>
+        {info.rules.map((rule) => (
+          <List.Item key={rule} icon={<IconInfoCircle size={12} />}>
+            {rule}
+          </List.Item>
+        ))}
+      </List>
+    </Stack>
+  );
+}
+
+PieceCard.propTypes = {
+  piece: PropTypes.shape({ name: PropTypes.string.isRequired }).isRequired,
+};
+
+/**
+ * Desktop-only sidebar replacing the old hover tooltip: shows info for
+ * whichever piece was last hovered, or - once both an origin and a target
+ * piece are selected for the current move - the predicted combat outcome.
+ */
+export default function PieceInfoPanel({ hoveredPiece, originPiece, destinationPiece }) {
+  const outcome =
+    originPiece && destinationPiece ? predictOutcome(originPiece, destinationPiece) : null;
+  const showOutcome = !!(outcome && destinationPiece);
+
+  return (
+    <Box
+      bg="rgb(224, 224, 224)"
+      sx={{
+        borderRadius: '1em',
+        padding: '1em',
+        width: '16em',
+        alignSelf: 'flex-start',
+      }}
+    >
+      <Text fw={700} mb="xs">
+        Piece Info
+      </Text>
+      {showOutcome ? (
+        <Stack spacing="sm">
+          <PieceCard piece={originPiece} />
+          <Divider label="attacks" labelPosition="center" />
+          <PieceCard piece={destinationPiece} />
+          <Divider />
+          <Text size="sm" fw={600} color={outcomeMessages[outcome.type]?.color}>
+            {outcomeMessages[outcome.type]?.text}
+          </Text>
+        </Stack>
+      ) : hoveredPiece ? (
+        <PieceCard piece={hoveredPiece} />
+      ) : (
+        <Text size="xs" c="dimmed">
+          Hover over a piece to see details.
+        </Text>
+      )}
+    </Box>
+  );
+}
+
+PieceInfoPanel.propTypes = {
+  hoveredPiece: PropTypes.object,
+  originPiece: PropTypes.object,
+  destinationPiece: PropTypes.object,
+};

--- a/src/components/PieceInfoPanel/index.jsx
+++ b/src/components/PieceInfoPanel/index.jsx
@@ -1,0 +1,1 @@
+export { default } from './PieceInfoPanel';

--- a/src/components/SelectablePosition.jsx
+++ b/src/components/SelectablePosition.jsx
@@ -1,5 +1,5 @@
+import { useEffect } from 'react';
 import Position from './Position';
-import GameTooltip from 'components/GameTooltip';
 import { Box } from '@mantine/core';
 import { useHover } from '@mantine/hooks';
 import PropTypes from 'prop-types';
@@ -54,7 +54,7 @@ export default function SelectablePosition({
   isLastMove = false,
   isEnglish,
   disabled = false,
-  gamePhase = 2,
+  onHoverPiece,
 }) {
   const { hovered, ref } = useHover();
   const shadeColor = getShadeColor(
@@ -66,7 +66,15 @@ export default function SelectablePosition({
     isLastMove
   );
 
-  const positionContent = (
+  // report hover to the parent (drives the desktop PieceInfoPanel) instead
+  // of the old per-tile tooltip; only fires while there's a real piece here
+  useEffect(() => {
+    if (hovered && piece && piece.name) {
+      onHoverPiece?.(piece);
+    }
+  }, [hovered]);
+
+  return (
     <Box
       sx={{
         cursor: disabled ? 'not-allowed' : 'pointer',
@@ -85,23 +93,6 @@ export default function SelectablePosition({
       />
     </Box>
   );
-
-  // Only show tooltip for pieces, not empty spaces
-  if (piece && piece.name) {
-    return (
-      <GameTooltip
-        pieceName={piece.name}
-        gamePhase={gamePhase}
-        isEnglish={isEnglish}
-        placement="top"
-        disabled={disabled}
-      >
-        {positionContent}
-      </GameTooltip>
-    );
-  }
-
-  return positionContent;
 }
 
 SelectablePosition.propTypes = {
@@ -116,5 +107,5 @@ SelectablePosition.propTypes = {
   isLastMove: PropTypes.bool,
   isEnglish: PropTypes.bool.isRequired,
   disabled: PropTypes.bool.isRequired,
-  gamePhase: PropTypes.number,
+  onHoverPiece: PropTypes.func,
 };

--- a/src/data/pieceInfo.js
+++ b/src/data/pieceInfo.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import * as Icons from '@tabler/icons-react';
+import pieceData from './pieceData.json';
+
+// map string names from JSON → actual icon components
+const iconMap = {
+  IconFlag: Icons.IconFlag,
+  IconBomb: Icons.IconBomb,
+  IconShieldHalfFilled: Icons.IconShieldHalfFilled,
+  IconTool: Icons.IconTool,
+  IconUserCircle: Icons.IconUserCircle,
+  IconUser: Icons.IconUser,
+  IconUserShield: Icons.IconUserShield,
+  IconChevronUp: Icons.IconChevronUp,
+  IconBadge: Icons.IconBadge,
+  IconStar: Icons.IconStar,
+  IconMedal: Icons.IconMedal,
+  IconShieldStar: Icons.IconShieldStar,
+  IconCrown: Icons.IconCrown,
+};
+
+/** Piece display info (title/description/rules/icon), keyed by piece name. */
+const pieceInfo = Object.fromEntries(
+  pieceData.map((piece) => [
+    piece.id,
+    {
+      ...piece,
+      icon: React.createElement(iconMap[piece.icon] || Icons.IconQuestionMark, { size: 16 }),
+    },
+  ])
+);
+
+export default pieceInfo;

--- a/src/utils/predictOutcome.js
+++ b/src/utils/predictOutcome.js
@@ -1,0 +1,40 @@
+/**
+ * Predicts the outcome of an attack given the attacking (source) piece and
+ * the piece currently on the target tile (or null for an empty tile).
+ * Mirrors the combat rules in the backend's pieceMovement, using only
+ * client-visible piece data - if the target's identity is hidden by fog of
+ * war (the generic 'enemy' placeholder), the true outcome can't be known.
+ *
+ * @param {Object} source the attacking piece (always known - it's your own)
+ * @param {Object|null} target the piece on the destination tile, or null
+ * @returns {{type: 'move'|'unknown'|'both-die'|'target-dies'|'source-dies'}|null}
+ */
+export function predictOutcome(source, target) {
+  if (!source) {
+    return null;
+  }
+  if (!target) {
+    return { type: 'move' };
+  }
+  if (target.name === 'enemy') {
+    return { type: 'unknown' };
+  }
+  if (source.affiliation === target.affiliation) {
+    return null;
+  }
+
+  if (
+    source.name === 'bomb' ||
+    source.name === target.name ||
+    target.name === 'bomb' ||
+    (source.name !== 'engineer' && target.name === 'landmine')
+  ) {
+    return { type: 'both-die' };
+  }
+
+  if (source.order > target.order || (source.name === 'engineer' && target.name === 'landmine')) {
+    return { type: 'target-dies' };
+  }
+
+  return { type: 'source-dies' };
+}


### PR DESCRIPTION
## Summary
- Removes the per-piece hover tooltip during gameplay and replaces it with a sidebar panel beside the board.
- Hovering a piece shows the same info the old tooltip had (title/description/rules), now sourced from a shared `data/pieceInfo.js` derivation instead of duplicating the icon-map/lookup logic that lived in `GameTooltip`.
- Once both an origin and a target piece are selected for the current move, the panel instead shows the predicted combat outcome (source dies / target dies / both die), via a new pure `predictOutcome()` utility mirroring the backend's `pieceMovement` combat rules. If the target's identity is hidden by fog of war, it reports the outcome as **unknown** rather than guessing from the fogged placeholder.
- Desktop-only for now: the panel needs room beside the board and is a hover-driven feature that doesn't translate to touch, so it's hidden below a 900px viewport width (`useWindowSize`).
- The setup-phase tooltip (`BoardSetup/HalfBoard`) is unchanged - only the gameplay board's tooltip is affected.

## Screenshots

**Hovering a piece shows its info in the sidebar:**
<img width="1400" height="1580" alt="info-1-hover-own-piece" src="https://github.com/user-attachments/assets/5e08eb99-1c1e-4acd-90f1-6c4b47d99fec" />


**Selecting a move against a still-hidden (fogged) enemy piece shows the "unknown outcome" message instead of a misleading guess:**
<img width="1400" height="1580" alt="info-2-outcome-unknown" src="https://github.com/user-attachments/assets/75f17704-08c3-4e55-b77a-f4c17f66ccd3" />

**Panel is entirely absent on mobile (375px viewport):**
<img width="375" height="1618" alt="info-3-mobile-no-panel" src="https://github.com/user-attachments/assets/10113f43-060c-4c7a-ad39-79f5cce1660b" />

## Test plan
- [x] `npm run build` and `npm run lint` (repo-wide, clean)
- [x] Verified live (Playwright, 1400px viewport): hovering a piece updates the panel with its info, no Mantine tooltip renders anywhere in the DOM, selecting an origin + a fogged enemy target shows the "identity is hidden" outcome message
- [x] Verified live at a 375px viewport: the panel is entirely absent (not just visually hidden), board layout unaffected