### PR TITLE
feat(gamecontext): toast notification when a field marshal dies

### DIFF
--- a/src/contexts/GameContext.jsx
+++ b/src/contexts/GameContext.jsx
@@ -1,6 +1,7 @@
 import React, { createContext, useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router';
 import { io } from 'socket.io-client';
+import { toast } from 'react-toastify';
 import { uniqueNamesGenerator, colors, animals } from 'unique-names-generator';
 import PropTypes from 'prop-types';
 
@@ -310,6 +311,19 @@ export const GameProvider = ({ children }) => {
       }
     });
 
+    /** Server is telling both players (and spectators) that a field marshal
+     * died on the move that just resolved - notable since the loser's flag
+     * becomes revealed to their opponent once this happens */
+    socket.on('fieldMarshallDown', (fallen) => {
+      fallen.forEach(({ playerName: fallenPlayerName }) => {
+        const isMine = fallenPlayerName === playerNameRef.current;
+        const message = isMine
+          ? 'Your Field Marshal has fallen!'
+          : `${fallenPlayerName}'s Field Marshal has fallen — their flag is now revealed!`;
+        toast.warning(message, { autoClose: 6000 });
+      });
+    });
+
     /** Server is telling all clients the game has ended */
     socket.on('endGame', ({ winnerIndex, gameStats, finalGame }) => {
       setGamePhase(3);
@@ -323,11 +337,14 @@ export const GameProvider = ({ children }) => {
       pushErrors(errMsg);
     });
 
+    // this effect re-runs on every roomId/errors change and re-registers
+    // every listener above from scratch - without removing the old set
+    // first, they'd silently pile up (each firing an extra time per
+    // re-run), which is exactly what was happening before this cleanup
+    // existed: side-effecting handlers like the fieldMarshallDown toast
+    // below would fire multiple times for a single server event.
     return () => {
-      socket.on('disconnect', () => {
-        console.info(`SocketID: ${socket.id}`);
-        console.info(`Connected: ${socket.connected}`);
-      });
+      socket.off();
     };
   }, [roomId, JSON.stringify(errors)]);
 

--- a/src/contexts/GameContext.jsx
+++ b/src/contexts/GameContext.jsx
@@ -337,12 +337,8 @@ export const GameProvider = ({ children }) => {
       pushErrors(errMsg);
     });
 
-    // this effect re-runs on every roomId/errors change and re-registers
-    // every listener above from scratch - without removing the old set
-    // first, they'd silently pile up (each firing an extra time per
-    // re-run), which is exactly what was happening before this cleanup
-    // existed: side-effecting handlers like the fieldMarshallDown toast
-    // below would fire multiple times for a single server event.
+    // this effect re-registers every listener above from scratch on each
+    // run, so the old set must be removed first or they'll pile up
     return () => {
       socket.off();
     };


### PR DESCRIPTION
## Summary
Pairs with the backend PR: chinese-board-games/luzhanqi-backend#69

- Listens for the backend's new `fieldMarshallDown` event and shows a temporary toast to both players (and spectators) - worded "Your Field Marshal has fallen!" for the player who lost it, vs. "\<name\>'s Field Marshal has fallen — their flag is now revealed!" for everyone else, since that's the actual gameplay consequence (see `emplaceBoardFog`).

## Also fixes a real bug this surfaced
The big socket-listener-registering effect in `GameContext` re-runs on every `roomId`/`errors` change but its cleanup function didn't remove any of the ~20 listeners it had just added - it mistakenly registered *another* `'disconnect'` listener instead of cleaning up. They were silently piling up all session. Most handlers are idempotent-ish state setters so this went unnoticed, but a side-effecting handler like a toast call made it immediately obvious: the field marshal toast was firing twice for a single server event. Cleanup now calls `socket.off()` to clear every listener before the next re-registration. Confirmed no other component attaches its own listeners to this shared socket, so a blanket `off()` is safe.

## Test plan
- [x] `npm run build` and `npm run lint` (repo-wide, clean)
- [x] Verified live: seeded a board (backend PR) forcing a field marshal death, confirmed the toast appears with correct wording
- [x] Confirmed the duplicate-listener bug reproduced consistently before the fix (2 identical toasts per event) and is gone after it (exactly 1)