### PR TITLE
feat(menu): rejoin banner for logged-in users on a new device

### DIFF
--- a/src/contexts/GameContext.jsx
+++ b/src/contexts/GameContext.jsx
@@ -104,23 +104,42 @@ export const GameProvider = ({ children }) => {
   const [rejoining, setRejoining] = useState(false);
   /** name of the opponent whose socket most recently disconnected, or null */
   const [disconnectedPlayer, setDisconnectedPlayer] = useState(null);
+  /** in-progress games tied to the logged-in user's account that are worth
+   * rejoining (opponent connected, or an AI game), from a device with no
+   * localStorage session for them - see checkActiveGames */
+  const [activeGames, setActiveGames] = useState([]);
 
-  /** Attempts to silently reclaim a seat using a locally-stored session token. Returns
-   * false immediately if no stored session exists for this game ID. */
-  const attemptRejoin = (gameId) => {
+  /** Attempts to reclaim a seat using a locally-stored session token if one
+   * exists for this game ID, otherwise (given a logged-in uid) falls back
+   * to asking the server to match the uid against the game's players.
+   * Returns false immediately if neither is available. */
+  const attemptRejoin = (gameId, uid = null) => {
     const session = loadSession(gameId);
-    if (!session) {
+    if (!session && !uid) {
       setRejoining(false);
       return false;
     }
     setRejoining(true);
-    setPlayerName(session.playerName);
+    if (session) {
+      setPlayerName(session.playerName);
+    }
     socket.emit('playerRejoinRoom', {
       gameId,
-      playerName: session.playerName,
-      token: session.token,
+      playerName: session?.playerName,
+      token: session?.token,
+      uid,
     });
     return true;
+  };
+
+  /** Asks the server which of the logged-in user's games are still ongoing
+   * and worth showing a "rejoin" prompt for. Results land in activeGames. */
+  const checkActiveGames = (uid) => {
+    if (!uid) {
+      setActiveGames([]);
+      return;
+    }
+    socket.emit('getMyActiveGames', { uid });
   };
 
   const gameState = {
@@ -151,7 +170,9 @@ export const GameProvider = ({ children }) => {
     errors: { errors, setErrors },
     rejoining: { rejoining, setRejoining },
     disconnectedPlayer: { disconnectedPlayer, setDisconnectedPlayer },
+    activeGames: { activeGames, setActiveGames },
     attemptRejoin,
+    checkActiveGames,
   };
 
   // extend error (list of errors) to include new errors
@@ -206,10 +227,13 @@ export const GameProvider = ({ children }) => {
       if (Array.isArray(data.spectators)) setSpectatorList(data.spectators);
     });
 
-    /** A stored session successfully reclaimed a seat after a disconnect/reload */
+    /** A stored session, or (from a device with none) a logged-in uid
+     * matching a seat, successfully reclaimed a seat after a disconnect */
     socket.on('youHaveRejoinedTheRoom', (data) => {
       setRejoining(false);
       setJoinedGame(true);
+      setPlayerName(data.playerName);
+      saveSession(data.gameId, data.playerName, data.token);
       setPlayerList(data.players || []);
       setSpectatorList(data.spectators || []);
       setHost(data.players?.[0] === data.playerName);
@@ -242,6 +266,12 @@ export const GameProvider = ({ children }) => {
 
     socket.on('playerReconnected', ({ playerName: returnedName }) => {
       setDisconnectedPlayer((current) => (current === returnedName ? null : current));
+    });
+
+    /** Server's answer to checkActiveGames - games tied to this account
+     * that are still ongoing and worth prompting the user to rejoin */
+    socket.on('myActiveGames', (games) => {
+      setActiveGames(Array.isArray(games) ? games : []);
     });
 
     socket.on('playerLeftRoom', ({ playerName: returnedPlayerName, players }) => {

--- a/src/views/Game.jsx
+++ b/src/views/Game.jsx
@@ -51,10 +51,12 @@ const Game = () => {
   }, [lastMove]);
 
   /** On mount (or a hard reload), silently try to reclaim a seat using a
-   * locally-stored session before falling back to the normal join form. */
+   * locally-stored session - or, on a device with none but a logged-in
+   * uid, ask the server to match that uid against the game's players -
+   * before falling back to the normal join form. */
   useEffect(() => {
     if (roomId && !joinedGame && playerList.length === 0) {
-      attemptRejoin(roomId);
+      attemptRejoin(roomId, uid);
     }
     // only re-run when the room in the URL changes, not on every state update
   }, [roomId]);

--- a/src/views/Menu.jsx
+++ b/src/views/Menu.jsx
@@ -18,6 +18,8 @@ function Menu({ joinedRoom = false, urlRoomId = '' }) {
     host: { setHost },
     errors: { errors, setErrors },
     isEnglish: { isEnglish },
+    activeGames: { activeGames },
+    checkActiveGames,
   } = useContext(GameContext);
 
   const user = useFirebaseAuth();
@@ -37,6 +39,15 @@ function Menu({ joinedRoom = false, urlRoomId = '' }) {
       setRoomId(urlRoomId);
     }
   });
+
+  // only on the real landing page (not the in-game "join" fallback form),
+  // ask whether this logged-in account has other games worth rejoining -
+  // notably covers logging in from a device with no local session for them
+  useEffect(() => {
+    if (!joinedRoom && user?.uid) {
+      checkActiveGames(user.uid);
+    }
+  }, [joinedRoom, user?.uid]);
 
   const viewStyle = {
     backgroundColor: '#d0edf5',
@@ -316,6 +327,21 @@ function Menu({ joinedRoom = false, urlRoomId = '' }) {
     <>
       <Container style={viewStyle}>
         <Container style={stackStyle}>
+          {!joinedRoom && activeGames.length > 0 ? (
+            <Container style={cardStyle}>
+              <Title order={3}>Rejoin a Game</Title>
+              {activeGames.map((game) => (
+                <Container key={game.gameId} style={cardContentStyle}>
+                  <Text size="sm" style={{ flex: 1 }}>
+                    {game.isAiGame ? 'vs. Computer' : `vs. ${game.opponentName}`}
+                  </Text>
+                  <Link to={`/game/${game.gameId}`} style={linkStyle}>
+                    <Button size="xs">Rejoin</Button>
+                  </Link>
+                </Container>
+              ))}
+            </Container>
+          ) : null}
           {joinedRoom ? null : <CreateForm />}
           <JoinForm urlRoomId={urlRoomId} />
           <SpectateForm urlRoomId={urlRoomId} />


### PR DESCRIPTION
## Summary
Pairs with the backend PR: chinese-board-games/luzhanqi-backend#71

- `GameContext`'s `attemptRejoin` now takes an optional `uid`, sent alongside whatever local session exists (or in place of one, if there isn't any) - `Game.jsx` passes the Firebase `uid` through. `youHaveRejoinedTheRoom` now also sets `playerName` and caches the returned session token locally, since a fresh device won't have either yet.
- `Menu.jsx` asks the server (via the new `checkActiveGames`/`getMyActiveGames` round trip) which of the logged-in user's games are worth rejoining, and shows a "Rejoin a Game" card above the create-game form listing each one (vs. Computer, or vs. `<opponent name>`) with a direct link into `/game/:gameId`, where the uid-based rejoin flow takes over.

## Test plan
- [x] `npm run build` and `npm run lint` (repo-wide, clean)
- [x] Verified live: the banner is correctly absent (no console errors) when logged out
- [x] The uid-based rejoin/active-games logic itself is verified in the paired backend PR via a raw `socket.io-client` script, since exercising the real banner requires an actual Firebase sign-in this environment doesn't have credentials for