### PR TITLE
feat(profile): archive/rejoin actions in the banner and game history

### DIFF
--- a/src/api/User.js
+++ b/src/api/User.js
@@ -41,6 +41,14 @@ export const removeGame = async (userId, gameId) => {
   });
 };
 
+/** Dismisses a game from the user's "rejoin" prompt without removing it
+ * from their games list - it still shows up in full game history. */
+export const archiveGame = async (userId, gameId) => {
+  return axios.post(`/user/${userId}/games/${gameId}/archive`).catch((err) => {
+    console.error(err);
+  });
+};
+
 export const getGames = async (userId) => {
   return axios.get(`/user/${userId}/games`).catch((err) => {
     console.error(err);

--- a/src/api/User.js
+++ b/src/api/User.js
@@ -49,6 +49,12 @@ export const archiveGame = async (userId, gameId) => {
   });
 };
 
+export const unarchiveGame = async (userId, gameId) => {
+  return axios.delete(`/user/${userId}/games/${gameId}/archive`).catch((err) => {
+    console.error(err);
+  });
+};
+
 export const getGames = async (userId) => {
   return axios.get(`/user/${userId}/games`).catch((err) => {
     console.error(err);

--- a/src/components/UserModal/UserModal.jsx
+++ b/src/components/UserModal/UserModal.jsx
@@ -139,11 +139,9 @@ const UserModal = ({ showModal, setShowModal }) => {
                     <td>{myGame.hostId === user?.uid ? myGame.players[1] : myGame.players[0]}</td>
                   )}
                   <td>
-                    <p>
-                      {myGame.winnerId === user?.uid
-                        ? 'Win'
-                        : (myGame.winnerId && 'Loss') ?? 'Incomplete'}
-                    </p>
+                    {myGame.winnerId === user?.uid
+                      ? 'Win'
+                      : (myGame.winnerId && 'Loss') ?? 'Incomplete'}
                   </td>
                   <td>
                     {isIncomplete ? (

--- a/src/components/UserModal/UserModal.jsx
+++ b/src/components/UserModal/UserModal.jsx
@@ -7,7 +7,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { useFirebaseAuth } from 'contexts/FirebaseContext';
 import { Table } from '@mantine/core';
-import { getUser, createUser, archiveGame } from 'api/User';
+import { getUser, createUser, archiveGame, unarchiveGame } from 'api/User';
 import { getGameById } from 'api/Game';
 
 const UserModal = ({ showModal, setShowModal }) => {
@@ -61,6 +61,15 @@ const UserModal = ({ showModal, setShowModal }) => {
   const handleArchive = async (gameId) => {
     await archiveGame(user.uid, gameId);
     setArchivedIds((prev) => new Set(prev).add(gameId));
+  };
+
+  const handleUnarchive = async (gameId) => {
+    await unarchiveGame(user.uid, gameId);
+    setArchivedIds((prev) => {
+      const next = new Set(prev);
+      next.delete(gameId);
+      return next;
+    });
   };
 
   return (
@@ -138,22 +147,33 @@ const UserModal = ({ showModal, setShowModal }) => {
                   </td>
                   <td>
                     {isIncomplete ? (
-                      <div style={{ display: 'flex', gap: '0.4em' }}>
-                        <Button size="xs" onClick={() => handleRejoin(myGame._id)}>
-                          Rejoin
-                        </Button>
+                      <div style={{ display: 'flex', gap: '0.4em', alignItems: 'center' }}>
                         {archivedIds.has(myGame._id) ? (
-                          <Text size="xs" c="dimmed">
-                            Archived
-                          </Text>
+                          <>
+                            <Text size="xs" c="dimmed">
+                              Archived
+                            </Text>
+                            <Button
+                              size="xs"
+                              variant="outline"
+                              onClick={() => handleUnarchive(myGame._id)}
+                            >
+                              Unarchive
+                            </Button>
+                          </>
                         ) : (
-                          <Button
-                            size="xs"
-                            variant="outline"
-                            onClick={() => handleArchive(myGame._id)}
-                          >
-                            Archive
-                          </Button>
+                          <>
+                            <Button size="xs" onClick={() => handleRejoin(myGame._id)}>
+                              Rejoin
+                            </Button>
+                            <Button
+                              size="xs"
+                              variant="outline"
+                              onClick={() => handleArchive(myGame._id)}
+                            >
+                              Archive
+                            </Button>
+                          </>
                         )}
                       </div>
                     ) : null}

--- a/src/components/UserModal/UserModal.jsx
+++ b/src/components/UserModal/UserModal.jsx
@@ -3,16 +3,19 @@ import { Button, Title, Text } from '@mantine/core';
 import Modal from 'react-modal';
 import PropTypes from 'prop-types';
 import { isEmpty } from 'lodash';
+import { useNavigate } from 'react-router-dom';
 
 import { useFirebaseAuth } from 'contexts/FirebaseContext';
 import { Table } from '@mantine/core';
-import { getUser, createUser } from 'api/User';
+import { getUser, createUser, archiveGame } from 'api/User';
 import { getGameById } from 'api/Game';
 
 const UserModal = ({ showModal, setShowModal }) => {
   const user = useFirebaseAuth();
+  const navigate = useNavigate();
   const [userData, setUserData] = useState({});
   const [gameData, setGameData] = useState([]);
+  const [archivedIds, setArchivedIds] = useState(new Set());
 
   useEffect(async () => {
     const fetchUser = async () => {
@@ -22,6 +25,7 @@ const UserModal = ({ showModal, setShowModal }) => {
         myUser = await createUser(user.uid);
       }
       setUserData(myUser);
+      setArchivedIds(new Set(myUser?.archivedGames || []));
       return myUser;
     };
 
@@ -48,6 +52,16 @@ const UserModal = ({ showModal, setShowModal }) => {
       fetchGames(myUser);
     }
   }, [setUserData, user?.uid, showModal]);
+
+  const handleRejoin = (gameId) => {
+    setShowModal(false);
+    navigate(`/game/${gameId}`);
+  };
+
+  const handleArchive = async (gameId) => {
+    await archiveGame(user.uid, gameId);
+    setArchivedIds((prev) => new Set(prev).add(gameId));
+  };
 
   return (
     <Modal
@@ -97,6 +111,7 @@ const UserModal = ({ showModal, setShowModal }) => {
               <th>Date</th>
               <th>Opponent</th>
               <th>Result</th>
+              <th>Actions</th>
             </tr>
           </thead>
           <tbody>
@@ -105,6 +120,7 @@ const UserModal = ({ showModal, setShowModal }) => {
                 console.warn(`Failure to fetch a game:`, myGame);
                 return;
               }
+              const isIncomplete = !myGame.winnerId;
               return (
                 <tr key={myGame._id}>
                   <td>{new Date(myGame.createdAt).toLocaleDateString()}</td>
@@ -119,6 +135,28 @@ const UserModal = ({ showModal, setShowModal }) => {
                         ? 'Win'
                         : (myGame.winnerId && 'Loss') ?? 'Incomplete'}
                     </p>
+                  </td>
+                  <td>
+                    {isIncomplete ? (
+                      <div style={{ display: 'flex', gap: '0.4em' }}>
+                        <Button size="xs" onClick={() => handleRejoin(myGame._id)}>
+                          Rejoin
+                        </Button>
+                        {archivedIds.has(myGame._id) ? (
+                          <Text size="xs" c="dimmed">
+                            Archived
+                          </Text>
+                        ) : (
+                          <Button
+                            size="xs"
+                            variant="outline"
+                            onClick={() => handleArchive(myGame._id)}
+                          >
+                            Archive
+                          </Button>
+                        )}
+                      </div>
+                    ) : null}
                   </td>
                 </tr>
               );

--- a/src/views/Menu.jsx
+++ b/src/views/Menu.jsx
@@ -8,6 +8,7 @@ import { useFirebaseAuth } from 'contexts/FirebaseContext';
 import { useForm } from '@mantine/form';
 import { Title } from '@mantine/core';
 import HelpButton from '../components/HelpButton';
+import { archiveGame } from 'api/User';
 
 function Menu({ joinedRoom = false, urlRoomId = '' }) {
   const {
@@ -18,7 +19,7 @@ function Menu({ joinedRoom = false, urlRoomId = '' }) {
     host: { setHost },
     errors: { errors, setErrors },
     isEnglish: { isEnglish },
-    activeGames: { activeGames },
+    activeGames: { activeGames, setActiveGames },
     checkActiveGames,
   } = useContext(GameContext);
 
@@ -126,6 +127,14 @@ function Menu({ joinedRoom = false, urlRoomId = '' }) {
         'You must provide both a game number and a spectator name.',
       ]);
     }
+  };
+
+  /** Dismiss the rejoin prompt for a game without forcing the user to
+   * rejoin (and maybe forfeit) just to get rid of the notification. */
+  const handleArchive = async (gameId) => {
+    if (!user?.uid) return;
+    await archiveGame(user.uid, gameId);
+    setActiveGames((prev) => prev.filter((g) => g.gameId !== gameId));
   };
 
   const handleCreateSubmit = ({
@@ -330,7 +339,7 @@ function Menu({ joinedRoom = false, urlRoomId = '' }) {
           {!joinedRoom && activeGames.length > 0 ? (
             <Container style={cardStyle}>
               <Title order={3}>Rejoin a Game</Title>
-              {activeGames.map((game) => (
+              {activeGames.slice(0, 1).map((game) => (
                 <Container key={game.gameId} style={cardContentStyle}>
                   <Text size="sm" style={{ flex: 1 }}>
                     {game.isAiGame ? 'vs. Computer' : `vs. ${game.opponentName}`}
@@ -338,6 +347,9 @@ function Menu({ joinedRoom = false, urlRoomId = '' }) {
                   <Link to={`/game/${game.gameId}`} style={linkStyle}>
                     <Button size="xs">Rejoin</Button>
                   </Link>
+                  <Button size="xs" variant="outline" onClick={() => handleArchive(game.gameId)}>
+                    Archive
+                  </Button>
                 </Container>
               ))}
             </Container>


### PR DESCRIPTION
## Summary
Pairs with the backend PR: chinese-board-games/luzhanqi-backend#72

- Adds `archiveGame` to `api/User.js` (`POST /user/:userId/games/:gameId/archive`).
- `Menu.jsx`'s "Rejoin a Game" banner (now backed by a backend that only ever returns the single most recent qualifying game) gets an Archive button next to Rejoin, so a user whose opponent abandoned a game can dismiss the prompt without needing to rejoin and forfeit just to make it go away.
- `UserModal`'s game history table gets a new Actions column: incomplete games get Rejoin (navigates to `/game/:gameId`, closing the modal first) and Archive (shows "Archived" once clicked, tracked in local state seeded from the user's `archivedGames`) - unaffected by archiving, since history should show everything regardless of prompt-dismissal status.

## Test plan
- [x] `npm run build` and `npm run lint` (repo-wide, clean)
- [x] The backend behavior this depends on (most-recent-only filtering, archive/fallback/empty transitions) is verified in the paired backend PR via a raw socket + REST script