### PR TITLE
feat(lobby): show a short join code for sharing a game

### DIFF
--- a/src/components/Lobby/Lobby.jsx
+++ b/src/components/Lobby/Lobby.jsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect } from 'react';
-import { Button, Checkbox, Container, Title } from '@mantine/core';
+import { Button, Checkbox, Container, CopyButton, Text, Title } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { GameContext } from 'contexts/GameContext';
 import { ToastContainer, toast } from 'react-toastify';
@@ -9,6 +9,7 @@ const Lobby = () => {
   const {
     socket,
     roomId: { roomId },
+    joinCode: { joinCode },
     playerName: { playerName },
     playerList: { playerList },
     spectatorName: { spectatorName },
@@ -71,6 +72,21 @@ const Lobby = () => {
 
   return (
     <Container style={{ backgroundColor: '#d0edf5' }}>
+      {joinCode ? (
+        <Container style={{ display: 'flex', alignItems: 'center', gap: '0.5em', padding: 0 }}>
+          <Text size="sm">Room code:</Text>
+          <Text size="xl" weight={700} sx={{ fontFamily: 'monospace', letterSpacing: '0.15em' }}>
+            {joinCode}
+          </Text>
+          <CopyButton value={joinCode}>
+            {({ copied, copy }) => (
+              <Button size="xs" color={copied ? 'green' : 'blue'} onClick={copy}>
+                {copied ? 'Copied' : 'Copy'}
+              </Button>
+            )}
+          </CopyButton>
+        </Container>
+      ) : null}
       {
         /** You have joined the game and are waiting for the host to start */
         joinedGame && !host ? (

--- a/src/contexts/GameContext.jsx
+++ b/src/contexts/GameContext.jsx
@@ -50,6 +50,8 @@ export const GameProvider = ({ children }) => {
   const [spectatorName, setSpectatorName] = useState(defaultName);
   /** game ID assigned to host, or user-input: game Id entered by player */
   const [roomId, setRoomId] = useState('');
+  /** short human-shareable code resolving to roomId, for inviting others */
+  const [joinCode, setJoinCode] = useState('');
   const [storedPlayerName, setStoredPlayerName] = useState(null);
   const [storedRoomId, setStoredRoomId] = useState(null);
   const [storedPlayerList, setStoredPlayerList] = useState([]);
@@ -147,6 +149,7 @@ export const GameProvider = ({ children }) => {
     playerName: { playerName, setPlayerName },
     spectatorName: { spectatorName, setSpectatorName },
     roomId: { roomId, setRoomId },
+    joinCode: { joinCode, setJoinCode },
     storedPlayerName: { storedPlayerName, setStoredPlayerName },
     storedRoomId: { storedRoomId, setStoredRoomId },
     storedPlayerList: { storedPlayerList, setStoredPlayerList },
@@ -191,15 +194,19 @@ export const GameProvider = ({ children }) => {
     });
 
     /** Server has created a new game, only host receives this message */
-    socket.on('newGameCreated', ({ gameId, mySocketId, players, phase, token }) => {
-      const serverRoomId = gameId;
-      console.info(`GameID: ${serverRoomId}, SocketID: ${mySocketId}`);
-      setRoomId(serverRoomId);
-      setPlayerList(players);
-      saveSession(serverRoomId, playerNameRef.current, token);
-      if (typeof phase === 'number') setGamePhase(phase);
-      navigate(`/game/${serverRoomId}`);
-    });
+    socket.on(
+      'newGameCreated',
+      ({ gameId, joinCode: newJoinCode, mySocketId, players, phase, token }) => {
+        const serverRoomId = gameId;
+        console.info(`GameID: ${serverRoomId}, SocketID: ${mySocketId}`);
+        setRoomId(serverRoomId);
+        setJoinCode(newJoinCode || '');
+        setPlayerList(players);
+        saveSession(serverRoomId, playerNameRef.current, token);
+        if (typeof phase === 'number') setGamePhase(phase);
+        navigate(`/game/${serverRoomId}`);
+      }
+    );
 
     /** Server is telling all clients the game has started  */
     socket.on('beginNewGame', ({ mySocketId, roomId, turn }) => {
@@ -222,6 +229,7 @@ export const GameProvider = ({ children }) => {
       // setPlayerList(data.players);
       const joinedRoomId = data.joinRoomId || roomId;
       navigate(`/game/${joinedRoomId}`);
+      setJoinCode(data.joinCode || '');
       saveSession(joinedRoomId, playerNameRef.current, data.token);
       if (typeof data.phase === 'number') setGamePhase(data.phase);
       if (Array.isArray(data.spectators)) setSpectatorList(data.spectators);
@@ -308,9 +316,12 @@ export const GameProvider = ({ children }) => {
     );
 
     /** Server is telling this socket that it has joined a room */
-    socket.on('youAreSpectatingTheRoom', () => {
+    socket.on('youAreSpectatingTheRoom', (data) => {
       setJoinedGame(true);
-      navigate(`/game/${roomId}`);
+      const joinedRoomId = data?.gameId || roomId;
+      setRoomId(joinedRoomId);
+      setJoinCode(data?.joinCode || '');
+      navigate(`/game/${joinedRoomId}`);
     });
 
     /** Server is sending the starting board with all placed pieces */

--- a/src/views/Menu.jsx
+++ b/src/views/Menu.jsx
@@ -283,7 +283,7 @@ function Menu({ joinedRoom = false, urlRoomId = '' }) {
           />
           <TextInput
             label="Join game:"
-            placeholder="Ex. 6543eb06e81d62019d596562"
+            placeholder="Ex. 7K4X2P"
             {...joinForm.getInputProps('roomId')}
             disabled={!!urlRoomId}
           />
@@ -319,7 +319,7 @@ function Menu({ joinedRoom = false, urlRoomId = '' }) {
           />
           <TextInput
             label="Spectate game:"
-            placeholder="Ex. 6543eb06e81d62019d596562"
+            placeholder="Ex. 7K4X2P"
             {...spectateForm.getInputProps('roomId')}
             disabled={!!urlRoomId}
           />


### PR DESCRIPTION
## Summary
- Depends on backend PR chinese-board-games/luzhanqi-backend#73, which adds a 6-character join code to every game.
- The waiting room (Lobby) now displays the join code with its own copy button, alongside the existing "Copy URL" link.
- `GameContext` tracks the join code (from `newGameCreated`/`youHaveJoinedTheRoom`/`youAreSpectatingTheRoom`) and now navigates spectators using the server-resolved real game ID instead of stale client-side input — needed because a spectator can now type a join code instead of the full ID.
- Join/Spectate form placeholders updated from the old 24-char ObjectId example to a join-code example.

## Test plan
- [x] `npm run build` succeeds (PWA + regular build both fine)
- [x] Live-verified via Playwright against local dev servers: host creates a game, sees a 6-char code in the Lobby; a second browser context joins using only that code and lands on the canonical `/game/<id>` URL; host sees the guest appear in the player list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RHNokmAjWcnP6SJXn5ZKWi