### PR TITLE
feat(setup): offer multiple curated example board layouts

### DIFF
--- a/src/components/BoardSetup/HalfBoard.jsx
+++ b/src/components/BoardSetup/HalfBoard.jsx
@@ -10,6 +10,7 @@ import {
   Button,
   Box,
   Tooltip,
+  Menu,
 } from '@mantine/core';
 import {
   DragOverlay,
@@ -28,6 +29,7 @@ import GameTooltip from 'components/GameTooltip';
 import LineTo from 'react-lineto';
 import Position from '../Position';
 import { setupPieces, pieces } from '../../models/Piece';
+import { exampleBoards } from '../../data/exampleBoards';
 import {
   mapBoard,
   copyBoard,
@@ -66,20 +68,11 @@ export default function HalfBoard({ sendStartingBoard, playerList, playerName, i
 
   const boardCompleted = unplacedPieces.length === 0;
 
-  const setExampleOne = () => {
-    const example1 = [
-      ['major_general', 'lieutenant', 'colonel', 'engineer', 'major_general'],
-      ['engineer', 'none', 'field_marshall', 'none', 'engineer'],
-      ['colonel', 'lieutenant', 'none', 'bomb', 'major'],
-      ['brigadier_general', 'none', 'brigadier_general', 'none', 'lieutenant'],
-      ['bomb', 'landmine', 'general', 'captain', 'captain'],
-      ['landmine', 'flag', 'major', 'landmine', 'captain'],
-    ];
-
+  const setExample = (exampleBoardLayout) => {
     const exampleBoard = [...emptyBoard];
     const placedPieces = new Map();
 
-    example1.forEach((row, y) => {
+    exampleBoardLayout.forEach((row, y) => {
       row.forEach((pieceName, x) => {
         if (pieceName === 'none') {
           return;
@@ -218,14 +211,28 @@ export default function HalfBoard({ sendStartingBoard, playerList, playerName, i
       >
         <Stack>
           <Center>
-            <Title>Board Setup</Title>
+            <Title>{isEnglish ? 'Board Setup' : '棋盤佈局'}</Title>
           </Center>
           <Center>
             <Group>
-              <Button type="button" variant="secondary" onClick={setExampleOne}>
-                Set Example 1
-              </Button>
-              <Tooltip disabled={boardCompleted} label="You still have unplaced pieces!">
+              <Menu shadow="md" width={160}>
+                <Menu.Target>
+                  <Button type="button" variant="secondary">
+                    {isEnglish ? 'Use Example' : '使用範例佈局'} ▾
+                  </Button>
+                </Menu.Target>
+                <Menu.Dropdown>
+                  {exampleBoards.map((example) => (
+                    <Menu.Item key={example.name} onClick={() => setExample(example.board)}>
+                      {isEnglish ? example.name : example.name_zh}
+                    </Menu.Item>
+                  ))}
+                </Menu.Dropdown>
+              </Menu>
+              <Tooltip
+                disabled={boardCompleted}
+                label={isEnglish ? 'You still have unplaced pieces!' : '您還有棋子尚未放置！'}
+              >
                 <span>
                   <Button
                     disabled={!boardCompleted}
@@ -233,7 +240,7 @@ export default function HalfBoard({ sendStartingBoard, playerList, playerName, i
                     variant="info"
                     onClick={() => sendStartingBoard(halfBoard)}
                   >
-                    Send Board Placement
+                    {isEnglish ? 'Send Board Placement' : '送出棋盤佈局'}
                   </Button>
                 </span>
               </Tooltip>
@@ -245,7 +252,7 @@ export default function HalfBoard({ sendStartingBoard, playerList, playerName, i
                   setUnplacedPieces([...affiliatedPieces].sort((a, b) => a.order - b.order));
                 }}
               >
-                Reset Board
+                {isEnglish ? 'Reset Board' : '重設棋盤'}
               </Button>
             </Group>
           </Center>

--- a/src/data/exampleBoards.js
+++ b/src/data/exampleBoards.js
@@ -1,0 +1,46 @@
+/**
+ * Curated, rule-legal half-board layouts a player can apply with one click
+ * during setup. Row 0 is the frontline (nearest the mountains), row 5 is the
+ * HQ row - the same orientation HalfBoard.jsx edits in. 'none' marks the five
+ * camp cells, which must stay empty.
+ */
+export const exampleBoards = [
+  {
+    name: 'Example 1',
+    name_zh: '範例一',
+    board: [
+      ['major_general', 'lieutenant', 'colonel', 'engineer', 'major_general'],
+      ['engineer', 'none', 'field_marshall', 'none', 'engineer'],
+      ['colonel', 'lieutenant', 'none', 'bomb', 'major'],
+      ['brigadier_general', 'none', 'brigadier_general', 'none', 'lieutenant'],
+      ['bomb', 'landmine', 'general', 'captain', 'captain'],
+      ['landmine', 'flag', 'major', 'landmine', 'captain'],
+    ],
+  },
+  {
+    // fortress: strong pieces and landmines massed around a col-3 flag
+    name: 'Example 2',
+    name_zh: '範例二',
+    board: [
+      ['lieutenant', 'captain', 'colonel', 'captain', 'lieutenant'],
+      ['engineer', 'none', 'major_general', 'none', 'engineer'],
+      ['brigadier_general', 'major', 'none', 'captain', 'brigadier_general'],
+      ['colonel', 'none', 'general', 'none', 'engineer'],
+      ['bomb', 'landmine', 'major_general', 'lieutenant', 'bomb'],
+      ['landmine', 'major', 'field_marshall', 'flag', 'landmine'],
+    ],
+  },
+  {
+    // flanks: defense spread across both sides with a col-1 flag
+    name: 'Example 3',
+    name_zh: '範例三',
+    board: [
+      ['captain', 'lieutenant', 'colonel', 'lieutenant', 'captain'],
+      ['engineer', 'none', 'general', 'none', 'engineer'],
+      ['major', 'brigadier_general', 'none', 'brigadier_general', 'major'],
+      ['engineer', 'none', 'major_general', 'none', 'colonel'],
+      ['landmine', 'captain', 'major_general', 'field_marshall', 'bomb'],
+      ['bomb', 'flag', 'landmine', 'lieutenant', 'landmine'],
+    ],
+  },
+];


### PR DESCRIPTION
## Summary
- Replaces the single "Set Example 1" button in Board Setup with a dropdown menu (`src/data/exampleBoards.js`) offering three named, rule-legal formations a player can apply with one click.
- Also translates the Board Setup toolbar to Chinese while touching this file (see the separate i18n PR #135 for the rest of the app - this file's translations are bundled here instead since the toolbar was being restructured anyway).
- Pairs with a backend change (luzhanqi-backend, separate PR) where the AI opponent now randomly picks among these same three curated layouts instead of a fully random shuffle - giving it sensible-looking placements instead of an arbitrary one.
<img width="887" height="948" alt="Screenshot 2026-07-15 at 15 00 08" src="https://github.com/user-attachments/assets/d07df0be-a07f-4a2b-a4af-ea72e72e37e9" />

## Test plan
- [x] `npm run build` succeeds
- [x] `eslint` clean (0 errors)
- [x] Live-verified via Playwright: created a vs-AI game, opened the example menu (confirmed all 3 options listed), applied "Example 2", confirmed the board filled correctly and "Send Board Placement" became enabled; screenshot matches the intended layout exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RHNokmAjWcnP6SJXn5ZKWi