### PR TITLE
feat(rules): make landminesSurvive, flyingBombs, and captureTheFlag configurable in the Lobby

### DIFF
--- a/src/components/GameBoard/index.jsx
+++ b/src/components/GameBoard/index.jsx
@@ -27,6 +27,7 @@ export default function GameBoard({
   forfeit,
   affiliation,
   isEnglish = false,
+  gameConfig = {},
   isSpectator = false,
   gamePhase = 2,
   lastMove = null,
@@ -44,7 +45,11 @@ export default function GameBoard({
   const originPiece = originSelected ? board[origin[0]][origin[1]] : null;
   const destinationPiece = destinationSelected ? board[destination[0]][destination[1]] : null;
 
-  const moves = originSelected ? getSuccessors(board, origin[0], origin[1], affiliation) : [];
+  const moves = originSelected
+    ? getSuccessors(board, origin[0], origin[1], affiliation, {
+        flyingBombs: gameConfig.flyingBombs,
+      })
+    : [];
   const availibleMoves = new Set(moves.map((move) => JSON.stringify(move)));
 
   const positionDisabled = (row, col) => {
@@ -209,6 +214,7 @@ export default function GameBoard({
             originPiece={originPiece}
             destinationPiece={destinationPiece}
             isEnglish={isEnglish}
+            gameConfig={gameConfig}
           />
         ) : null}
       </Flex>
@@ -228,6 +234,7 @@ GameBoard.propTypes = {
   opponent: PropTypes.string,
   affiliation: PropTypes.number,
   isEnglish: PropTypes.bool,
+  gameConfig: PropTypes.object,
   isSpectator: PropTypes.bool,
   gamePhase: PropTypes.number,
   lastMove: PropTypes.shape({

--- a/src/components/Lobby/Lobby.jsx
+++ b/src/components/Lobby/Lobby.jsx
@@ -24,6 +24,9 @@ const Lobby = () => {
   const configForm = useForm({
     initialValues: {
       fogOfWar: true,
+      landminesSurvive: false,
+      flyingBombs: false,
+      captureTheFlag: false,
     },
   });
 
@@ -135,6 +138,33 @@ const Lobby = () => {
                 mt="md"
                 label={isEnglish ? 'Enable fog of war' : '啟用戰爭迷霧'}
                 {...configForm.getInputProps('fogOfWar', { type: 'checkbox' })}
+              />
+              <Checkbox
+                mt="sm"
+                label={
+                  isEnglish
+                    ? 'Landmines survive (only the attacker dies)'
+                    : '地雷不會被摧毀（只有攻擊方陣亡）'
+                }
+                {...configForm.getInputProps('landminesSurvive', { type: 'checkbox' })}
+              />
+              <Checkbox
+                mt="sm"
+                label={
+                  isEnglish
+                    ? 'Flying bombs (bombs move like the Engineer)'
+                    : '飛彈（炸彈可像工兵一樣轉彎移動）'
+                }
+                {...configForm.getInputProps('flyingBombs', { type: 'checkbox' })}
+              />
+              <Checkbox
+                mt="sm"
+                label={
+                  isEnglish
+                    ? 'Capture the flag (carry it back to your HQ to win)'
+                    : '奪旗規則（需將軍旗帶回己方大本營才能獲勝）'
+                }
+                {...configForm.getInputProps('captureTheFlag', { type: 'checkbox' })}
               />
             </form>
           </>

--- a/src/components/PieceInfoPanel/PieceInfoPanel.jsx
+++ b/src/components/PieceInfoPanel/PieceInfoPanel.jsx
@@ -71,9 +71,12 @@ export default function PieceInfoPanel({
   originPiece,
   destinationPiece,
   isEnglish = false,
+  gameConfig = {},
 }) {
   const outcome =
-    originPiece && destinationPiece ? predictOutcome(originPiece, destinationPiece) : null;
+    originPiece && destinationPiece
+      ? predictOutcome(originPiece, destinationPiece, gameConfig)
+      : null;
   const showOutcome = !!(outcome && destinationPiece);
 
   return (
@@ -117,4 +120,5 @@ PieceInfoPanel.propTypes = {
   originPiece: PropTypes.object,
   destinationPiece: PropTypes.object,
   isEnglish: PropTypes.bool,
+  gameConfig: PropTypes.object,
 };

--- a/src/contexts/GameContext.jsx
+++ b/src/contexts/GameContext.jsx
@@ -77,6 +77,10 @@ export const GameProvider = ({ children }) => {
   });
   const [successors, setSuccessors] = useState([]);
   const [isEnglish, setIsEnglish] = useState(false);
+  // rule-variant config (flyingBombs/landminesSurvive/captureTheFlag/...)
+  // set by the host in the Lobby - needed locally so move highlighting and
+  // combat-outcome prediction match how the server will actually resolve them
+  const [gameConfig, setGameConfig] = useState({});
   // mirrors playerNameRef above - lets the socket handlers below (registered
   // in an effect that doesn't re-run on every isEnglish change) always read
   // the current language instead of a stale closure
@@ -177,6 +181,7 @@ export const GameProvider = ({ children }) => {
     winner: { winner, setWinner },
     gameResults: { gameResults, setGameResults },
     isEnglish: { isEnglish, setIsEnglish },
+    gameConfig: { gameConfig, setGameConfig },
     errors: { errors, setErrors },
     rejoining: { rejoining, setRejoining },
     disconnectedPlayer: { disconnectedPlayer, setDisconnectedPlayer },
@@ -264,6 +269,7 @@ export const GameProvider = ({ children }) => {
         setWinner(data.winnerIndex);
         if (data.gameStats) setGameResults(data.gameStats);
       }
+      if (data.config) setGameConfig(data.config);
       setRoomId(data.gameId);
       navigate(`/game/${data.gameId}`);
     });
@@ -339,6 +345,7 @@ export const GameProvider = ({ children }) => {
       // normally set by beginNewGame, but that event never fires for AI
       // games since they skip the Lobby's "Room Full" step entirely
       if (typeof game.turn === 'number') setClientTurn(game.turn);
+      if (game.config) setGameConfig(game.config);
     });
 
     socket.on('halfBoardReceived', () => {

--- a/src/utils/getSuccessors.js
+++ b/src/utils/getSuccessors.js
@@ -88,8 +88,10 @@ export function _getEngineerRailroadMoves(board, r, c, affiliation) {
   if (!isRailroad(r, c)) {
     return railroadMoves;
   }
-  if (board[r][c]?.name !== 'engineer') {
-    throw Error(`Position [${r}, ${c}] is not an engineer.`);
+  // also used for a bomb under the flyingBombs rule variant, which grants
+  // it the same corner-turning railroad movement as the Engineer
+  if (!['engineer', 'bomb'].includes(board[r][c]?.name || '')) {
+    throw Error(`Position [${r}, ${c}] is not an engineer or bomb.`);
   }
   // perform dfs to find availible moves
   const stack = [[r, c]];
@@ -166,12 +168,14 @@ export function _getNormalRailroadMoves(board, r, c, affiliation) {
  * @param {number} r The row index of the source coordinate pair.
  * @param {number} c The column index of the source coordinate pair.
  * @param {number} affiliation 0 for host, increments by 1 for additional players.
+ * @param {{flyingBombs?: boolean}} config When flyingBombs is set, a Bomb gets
+ *   the same corner-turning railroad movement as the Engineer.
  * @see getSuccessors
  * @throws Will throw an error if the board is not 12 by 5 and/or if the source
  *   row/col is out of bounds.
  * @returns {Array} List of positions that the piece may travel to during its turn.
  */
-export function getSuccessors(board, r, c, affiliation) {
+export function getSuccessors(board, r, c, affiliation, config = {}) {
   // validate the board
   if (board.length !== 12) {
     throw 'Invalid number of rows in board';
@@ -196,10 +200,11 @@ export function getSuccessors(board, r, c, affiliation) {
   ) {
     return [];
   }
-  const railroadMoves =
-    piece.name === 'engineer'
-      ? _getEngineerRailroadMoves(board, r, c, affiliation)
-      : _getNormalRailroadMoves(board, r, c, affiliation);
+  const hasFullTurnMovement =
+    piece.name === 'engineer' || (config.flyingBombs && piece.name === 'bomb');
+  const railroadMoves = hasFullTurnMovement
+    ? _getEngineerRailroadMoves(board, r, c, affiliation)
+    : _getNormalRailroadMoves(board, r, c, affiliation);
   const adjListMoves =
     [...(adjList.get(JSON.stringify([r, c])) || [])]
       ?.map((str) => JSON.parse(str))

--- a/src/utils/predictOutcome.js
+++ b/src/utils/predictOutcome.js
@@ -7,9 +7,10 @@
  *
  * @param {Object} source the attacking piece (always known - it's your own)
  * @param {Object|null} target the piece on the destination tile, or null
+ * @param {{landminesSurvive?: boolean}} config the game's rule-variant config
  * @returns {{type: 'move'|'unknown'|'both-die'|'target-dies'|'source-dies'}|null}
  */
-export function predictOutcome(source, target) {
+export function predictOutcome(source, target, config = {}) {
   if (!source) {
     return null;
   }
@@ -23,12 +24,13 @@ export function predictOutcome(source, target) {
     return null;
   }
 
-  if (
-    source.name === 'bomb' ||
-    source.name === target.name ||
-    target.name === 'bomb' ||
-    (source.name !== 'engineer' && target.name === 'landmine')
-  ) {
+  if (source.name !== 'engineer' && target.name === 'landmine') {
+    // under landminesSurvive the mine stays and only the attacker dies,
+    // same outcome (for the attacker) as any other lost fight
+    return config.landminesSurvive ? { type: 'source-dies' } : { type: 'both-die' };
+  }
+
+  if (source.name === 'bomb' || source.name === target.name || target.name === 'bomb') {
     return { type: 'both-die' };
   }
 

--- a/src/views/Game.jsx
+++ b/src/views/Game.jsx
@@ -29,6 +29,7 @@ const Game = () => {
     myDeadPieces: { myDeadPieces },
     lastMove: { lastMove },
     isEnglish: { isEnglish },
+    gameConfig: { gameConfig },
     joinedGame: { joinedGame },
     rejoining: { rejoining },
     disconnectedPlayer: { disconnectedPlayer },
@@ -231,6 +232,7 @@ const Game = () => {
               opponentName={playerList[1 - affiliation]}
               affiliation={affiliation}
               isEnglish={isEnglish}
+              gameConfig={gameConfig}
               isSpectator={spectatorList.includes(spectatorName)}
               gamePhase={gamePhase}
               lastMove={displayLastMove}

--- a/src/views/Menu.jsx
+++ b/src/views/Menu.jsx
@@ -75,13 +75,15 @@ function Menu({ joinedRoom = false, urlRoomId = '' }) {
   const linkStyle = { color: 'white' };
 
   /** Tell the server to create a new game */
-  const createNewGame = (name, vsAi, aiSettings) => {
+  const createNewGame = (name, vsAi, aiSettings, rules) => {
     if (name) {
       setPlayerName(name);
       socket.emit('hostCreateNewGame', {
         playerName: name,
         hostId: user?.uid || null,
-        gameConfig: vsAi ? { opponentType: 'ai', aiSettings } : undefined,
+        // vsAi games skip the Lobby (where a human game's host would
+        // otherwise set these), so rules must be sent at creation time
+        gameConfig: vsAi ? { opponentType: 'ai', aiSettings, ...rules } : undefined,
       });
       setHost(true);
       // GameContext will redirect to /game when socket starts the game
@@ -151,8 +153,17 @@ function Menu({ joinedRoom = false, urlRoomId = '' }) {
     positionalDrive,
     caution,
     aggression,
+    fogOfWar,
+    landminesSurvive,
+    flyingBombs,
+    captureTheFlag,
   }) => {
-    createNewGame(playerName, vsAi, { randomness, positionalDrive, caution, aggression });
+    createNewGame(
+      playerName,
+      vsAi,
+      { randomness, positionalDrive, caution, aggression },
+      { fogOfWar, landminesSurvive, flyingBombs, captureTheFlag }
+    );
   };
 
   const handleJoinSubmit = ({ playerName, roomId }) => {
@@ -173,6 +184,11 @@ function Menu({ joinedRoom = false, urlRoomId = '' }) {
         positionalDrive: 0.15,
         caution: 0.5,
         aggression: 1,
+        // rule variants - defaults match createGame's resolvedConfig in the backend
+        fogOfWar: true,
+        landminesSurvive: false,
+        flyingBombs: false,
+        captureTheFlag: false,
       },
     });
     const vsAi = createForm.values.vsAi;
@@ -184,6 +200,7 @@ function Menu({ joinedRoom = false, urlRoomId = '' }) {
           <Tabs defaultValue="basic" keepMounted={false}>
             <Tabs.List>
               <Tabs.Tab value="basic">{isEnglish ? 'Basic' : '基本'}</Tabs.Tab>
+              {vsAi ? <Tabs.Tab value="rules">{isEnglish ? 'Rules' : '規則'}</Tabs.Tab> : null}
               {vsAi ? (
                 <Tabs.Tab value="advanced">{isEnglish ? 'Advanced' : '進階'}</Tabs.Tab>
               ) : null}
@@ -201,6 +218,43 @@ function Menu({ joinedRoom = false, urlRoomId = '' }) {
                 {...createForm.getInputProps('vsAi', { type: 'checkbox' })}
               />
             </Tabs.Panel>
+
+            {vsAi ? (
+              <Tabs.Panel value="rules" pt="sm">
+                <Checkbox
+                  mt="md"
+                  label={isEnglish ? 'Enable fog of war' : '啟用戰爭迷霧'}
+                  {...createForm.getInputProps('fogOfWar', { type: 'checkbox' })}
+                />
+                <Checkbox
+                  mt="sm"
+                  label={
+                    isEnglish
+                      ? 'Landmines survive (only the attacker dies)'
+                      : '地雷不會被摧毀（只有攻擊方陣亡）'
+                  }
+                  {...createForm.getInputProps('landminesSurvive', { type: 'checkbox' })}
+                />
+                <Checkbox
+                  mt="sm"
+                  label={
+                    isEnglish
+                      ? 'Flying bombs (bombs move like the Engineer)'
+                      : '飛彈（炸彈可像工兵一樣轉彎移動）'
+                  }
+                  {...createForm.getInputProps('flyingBombs', { type: 'checkbox' })}
+                />
+                <Checkbox
+                  mt="sm"
+                  label={
+                    isEnglish
+                      ? 'Capture the flag (carry it back to your HQ to win)'
+                      : '奪旗規則（需將軍旗帶回己方大本營才能獲勝）'
+                  }
+                  {...createForm.getInputProps('captureTheFlag', { type: 'checkbox' })}
+                />
+              </Tabs.Panel>
+            ) : null}
 
             {vsAi ? (
               <Tabs.Panel value="advanced" pt="sm">


### PR DESCRIPTION
Closes https://github.com/chinese-board-games/luzhanqi-web/issues/52 (with some changes in requirements).

## Summary
Depends on backend PR chinese-board-games/luzhanqi-backend#75, which adds these three rule variants to `Game.config`.

- Adds three checkboxes to the host's Lobby rules panel, alongside the existing "Enable fog of war" toggle: **Landmines survive**, **Flying bombs**, **Capture the flag**.
- `GameContext` now tracks the game's rule config (received on `boardSet` and `youHaveRejoinedTheRoom`) and exposes it as `gameConfig`.
- `getSuccessors.js` mirrors the backend's `flyingBombs`-aware corner-turning logic, so a bomb's highlighted legal moves match what the server will actually allow.
- `predictOutcome.js` treats a non-Engineer attacking a landmine as `source-dies` instead of `both-die` when `landminesSurvive` is on, so the PieceInfoPanel's combat-outcome preview stays accurate.
<img width="478" height="495" alt="Screenshot 2026-07-15 at 17 42 46" src="https://github.com/user-attachments/assets/a601a4a5-8724-4c15-ac1d-808c379b67a6" />

## Test plan
- [x] `npm run build` succeeds
- [x] `eslint` clean (0 errors)
- [x] Live-verified via Playwright: created a real 2-player game, checked all three new checkboxes in the Lobby, confirmed each ends up checked (`isChecked()`), clicked "Room Full", confirmed both host and guest transition into Board Setup with zero console errors
- [x] Also verified via a raw socket script (against the paired backend PR) that the config sent from this form round-trips through `hostRoomFull` and persists exactly as sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RHNokmAjWcnP6SJXn5ZKWi