### PR TITLE
fix(setup): stop the example-board picker from polluting future boards

### DIFF
--- a/src/components/BoardSetup/HalfBoard.jsx
+++ b/src/components/BoardSetup/HalfBoard.jsx
@@ -41,10 +41,12 @@ import {
 import useWindowSize from 'hooks/useWindowSize';
 import PropTypes from 'prop-types';
 
-const emptyBoard = [];
-for (let i = 0; i < 6; i++) {
-  emptyBoard.push([null, null, null, null, null]);
-}
+// returns a fresh 6x5 board every call - each row is a brand new array, so
+// callers can safely mutate individual cells without corrupting a shared
+// reference (a previous version returned the same row arrays every time,
+// so filling in an example board via direct cell assignment permanently
+// polluted every future "empty" board for the rest of the browser session)
+const makeEmptyBoard = () => Array.from({ length: 6 }, () => [null, null, null, null, null]);
 
 export default function HalfBoard({ sendStartingBoard, playerList, playerName, isEnglish }) {
   const sensors = useSensors(useSensor(MouseSensor), useSensor(TouchSensor));
@@ -58,7 +60,7 @@ export default function HalfBoard({ sendStartingBoard, playerList, playerName, i
   const [unplacedPieces, setUnplacedPieces] = useState(
     [...affiliatedPieces].sort((a, b) => a.order - b.order)
   );
-  const [halfBoard, setHalfboard] = useState([...emptyBoard]);
+  const [halfBoard, setHalfboard] = useState(makeEmptyBoard());
   const [activeId, setActiveId] = useState(null);
   // TODO: refactor this to be more effecient
   const activePiece =
@@ -69,7 +71,7 @@ export default function HalfBoard({ sendStartingBoard, playerList, playerName, i
   const boardCompleted = unplacedPieces.length === 0;
 
   const setExample = (exampleBoardLayout) => {
-    const exampleBoard = [...emptyBoard];
+    const exampleBoard = makeEmptyBoard();
     const placedPieces = new Map();
 
     exampleBoardLayout.forEach((row, y) => {
@@ -248,7 +250,7 @@ export default function HalfBoard({ sendStartingBoard, playerList, playerName, i
                 type="button"
                 color="red.6"
                 onClick={() => {
-                  setHalfboard([...emptyBoard]);
+                  setHalfboard(makeEmptyBoard());
                   setUnplacedPieces([...affiliatedPieces].sort((a, b) => a.order - b.order));
                 }}
               >


### PR DESCRIPTION
Fixes https://github.com/chinese-board-games/luzhanqi-web/issues/121

## Summary
`emptyBoard` in `HalfBoard.jsx` was a module-level array created once and shared for the life of the browser tab. `[...emptyBoard]` only copies the outer array - each of the 6 row arrays inside it stayed the exact same shared reference. `setExample` then wrote directly into cells of that "copy" (`exampleBoard[y][x] = piece`), which actually mutated the shared row arrays in place.

Once any example board was applied once, `emptyBoard` silently stopped being empty for the rest of the browser session: every later "empty" board (a fresh `HalfBoard` mount from starting another game, or clicking "Reset Board") inherited those leftover pieces, while the unplaced-pieces tray - rebuilt independently each time from `setupPieces` - still showed the full 25-piece set. Net effect: pieces appeared to exist both already-placed on the board *and* still-unplaced in the tray simultaneously.

Predates the multi-example picker (chinese-board-games/luzhanqi-web#136) - the original single "Set Example 1" button had the identical bug, just less exposure since there was only one example to trigger it.

Fix: replaces the shared constant with `makeEmptyBoard()`, which allocates fresh row arrays on every call, used consistently for the initial state, "Use Example", and "Reset Board".

## Test plan
- [x] `npm run build` succeeds
- [x] `eslint` clean (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RHNokmAjWcnP6SJXn5ZKWi