### PR TITLE
fix(board): remove animation delay from click-driven tile highlights

### DIFF
--- a/src/components/Position.jsx
+++ b/src/components/Position.jsx
@@ -18,6 +18,7 @@ export default function Position({
   isHalfBoard = false,
   isEnglish,
   disabled = false,
+  isLastMove = false,
 }) {
   const placedPiece =
     piece && piece.name && isHalfBoard
@@ -167,7 +168,10 @@ export default function Position({
       <Center
         mih="5em"
         bg={(!disabled && shadeColor) || 'transparent'}
-        sx={{ transition: 'background-color 1.5s ease-out' }}
+        // only the last-move fade-out should ease in/out - a click-driven
+        // highlight (origin/destination/attackable/movable) must apply
+        // immediately, with no delay
+        sx={{ transition: isLastMove ? 'background-color 1.5s ease-out' : 'none' }}
       >
         {getPositionContent()}
       </Center>
@@ -184,4 +188,5 @@ Position.propTypes = {
   isHalfBoard: PropTypes.bool.isRequired,
   isEnglish: PropTypes.bool.isRequired,
   disabled: PropTypes.bool,
+  isLastMove: PropTypes.bool,
 };

--- a/src/components/SelectablePosition.jsx
+++ b/src/components/SelectablePosition.jsx
@@ -90,6 +90,7 @@ export default function SelectablePosition({
         shadeColor={shadeColor}
         isHalfBoard={false}
         isEnglish={isEnglish}
+        isLastMove={isLastMove}
       />
     </Box>
   );


### PR DESCRIPTION
## Summary
`Position.jsx` applied a blanket `background-color 1.5s ease-out` transition to every board tile. This was added for the last-move fade-out effect (highlight the previous move, then let it fade after a couple seconds), but since it's one CSS rule shared by every tile regardless of why it's highlighted, it also delayed the origin/destination/attackable/movable highlight that's supposed to appear instantly when you click a piece - selection felt laggy.

Fix: the transition now only applies when `isLastMove` is true (threaded down from `SelectablePosition`, which already tracked this). Click-driven highlights apply with no delay; the last-move fade is untouched.

<img width="400" height="316" alt="Screen Recording 2026-07-15 at 17 49 37" src="https://github.com/user-attachments/assets/6d6558ae-b15e-45aa-bebf-e72812581c4d" />


## Test plan
- [x] `npm run build` succeeds, `eslint` clean
- [x] Live-verified via Playwright: started a vs-AI game, clicked a piece to select it, confirmed via `getComputedStyle` that no element on the board carries the 1.5s transition at that point (none should, since no move has happened yet to trigger the last-move highlight)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RHNokmAjWcnP6SJXn5ZKWi