### PR TITLE
feat(error-boundary): add app-level error boundary

### DIFF
--- a/src/components/ErrorBoundary/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Button, Flex, Title, Text } from '@mantine/core';
+import PropTypes from 'prop-types';
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    // eslint-disable-next-line no-console
+    console.error('Uncaught error:', error, errorInfo);
+  }
+
+  render() {
+    const { hasError } = this.state;
+    const { children } = this.props;
+
+    if (hasError) {
+      return (
+        <Flex
+          direction="column"
+          align="center"
+          justify="center"
+          style={{ height: '100vh', gap: '1em', textAlign: 'center', padding: '1em' }}
+        >
+          <Title order={2}>Something went wrong.</Title>
+          <Text>Please try reloading the page.</Text>
+          <Button color="violet" onClick={() => window.location.reload()}>
+            Reload
+          </Button>
+        </Flex>
+      );
+    }
+
+    return children;
+  }
+}
+
+ErrorBoundary.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default ErrorBoundary;

--- a/src/components/ErrorBoundary/index.jsx
+++ b/src/components/ErrorBoundary/index.jsx
@@ -1,0 +1,3 @@
+import ErrorBoundary from './ErrorBoundary';
+
+export default ErrorBoundary;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -7,6 +7,7 @@ import './index.css';
 import { GameProvider } from 'contexts/GameContext';
 import { FirebaseAuthProvider } from 'contexts/FirebaseContext';
 import { MantineProvider } from '@mantine/core';
+import ErrorBoundary from 'components/ErrorBoundary';
 import App from './App';
 import { CustomFonts } from './CustomFonts';
 import theme, { other } from './theme';
@@ -15,21 +16,23 @@ axios.defaults.baseURL = `${import.meta.env.VITE_API}`;
 
 ReactDOM.render(
   <React.StrictMode>
-    <BrowserRouter>
-      <FirebaseAuthProvider>
-        <MantineProvider
-          theme={{
-            ...theme,
-            other,
-          }}
-        >
-          <CustomFonts />
-          <GameProvider>
-            <App />
-          </GameProvider>
-        </MantineProvider>
-      </FirebaseAuthProvider>
-    </BrowserRouter>
+    <ErrorBoundary>
+      <BrowserRouter>
+        <FirebaseAuthProvider>
+          <MantineProvider
+            theme={{
+              ...theme,
+              other,
+            }}
+          >
+            <CustomFonts />
+            <GameProvider>
+              <App />
+            </GameProvider>
+          </MantineProvider>
+        </FirebaseAuthProvider>
+      </BrowserRouter>
+    </ErrorBoundary>
   </React.StrictMode>,
   document.getElementById('root')
 );


### PR DESCRIPTION
Wraps the entire tree so a render-phase or effect throw (e.g. Firebase auth misconfiguration in FirebaseAuthProvider/NavBar) shows a fallback UI instead of an unrecoverable blank page.

## Type of Change

- [X] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

## Screenshots

Please attach any design screenshots if UI update.
