### PR TITLE
fix(rules): bomb attacking a landmine always destroys both

### DIFF
--- a/src/utils/predictOutcome.js
+++ b/src/utils/predictOutcome.js
@@ -26,8 +26,11 @@ export function predictOutcome(source, target, config = {}) {
 
   if (source.name !== 'engineer' && target.name === 'landmine') {
     // under landminesSurvive the mine stays and only the attacker dies,
-    // same outcome (for the attacker) as any other lost fight
-    return config.landminesSurvive ? { type: 'source-dies' } : { type: 'both-die' };
+    // same outcome (for the attacker) as any other lost fight - except a
+    // bomb, which always trades with whatever it hits, mine included
+    return config.landminesSurvive && source.name !== 'bomb'
+      ? { type: 'source-dies' }
+      : { type: 'both-die' };
   }
 
   if (source.name === 'bomb' || source.name === target.name || target.name === 'bomb') {


### PR DESCRIPTION
Under the landminesSurvive variant, predictOutcome only special-cased the mine surviving for non-Engineer attackers in general, missing that a bomb should always trade with whatever it hits (mines included), matching the backend's pieceMovement behavior.

## Type of Change

- [ ] New feature
- [X] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

## Screenshots

Please attach any design screenshots if UI update.
