### PR TITLE
feat(gameboard): confirm moves with a card next to the target tile

### DIFF
--- a/src/components/GameBoard/index.jsx
+++ b/src/components/GameBoard/index.jsx
@@ -1,8 +1,9 @@
 import { useState, useEffect } from 'react';
-import { Grid, Container, Center, Stack, Button, Group, Flex } from '@mantine/core';
+import { Grid, Container, Center, Button, Flex, Popover } from '@mantine/core';
 import { emptyBoard } from 'utils/core';
 import SelectablePosition from '../SelectablePosition';
 import PieceInfoPanel from '../PieceInfoPanel';
+import MoveConfirmCard from '../MoveConfirmCard';
 import { isEqual } from 'lodash';
 import FrontLines from './FrontLines';
 import Mountain from './Mountain';
@@ -84,15 +85,17 @@ export default function GameBoard({
     [];
 
   const gridCells = board.flatMap((row, r) =>
-    row.map((piece, c) => (
-      <Grid.Col span={4} key={`${r}-${c}`}>
+    row.map((piece, c) => {
+      const isDestinationCell = isEqual(destination, [r, c]);
+
+      const cell = (
         <SelectablePosition
           piece={piece}
           row={r}
           col={c}
-          selected={isEqual(origin, [r, c]) || isEqual(destination, [r, c])}
+          selected={isEqual(origin, [r, c]) || isDestinationCell}
           originSelected={isEqual(origin, [r, c])}
-          destinationSelected={isEqual(destination, [r, c])}
+          destinationSelected={isDestinationCell}
           attackable={
             board[r][c] &&
             board[r][c].affiliation != affiliation &&
@@ -111,7 +114,7 @@ export default function GameBoard({
               setDestination(NO_SELECT);
               return;
             }
-            if (isEqual(destination, [r, c])) {
+            if (isDestinationCell) {
               setDestination(NO_SELECT);
               return;
             }
@@ -125,8 +128,43 @@ export default function GameBoard({
           disabled={positionDisabled(r, c)}
           onHoverPiece={setHoveredPiece}
         />
-      </Grid.Col>
-    ))
+      );
+
+      return (
+        <Grid.Col span={4} key={`${r}-${c}`}>
+          {isDestinationCell ? (
+            <Popover
+              opened
+              withinPortal
+              position="bottom"
+              withArrow
+              shadow="md"
+              radius="md"
+              trapFocus
+              closeOnClickOutside={false}
+            >
+              <Popover.Target>{cell}</Popover.Target>
+              <Popover.Dropdown>
+                <MoveConfirmCard
+                  originPiece={originPiece}
+                  destinationPiece={destinationPiece}
+                  gameConfig={gameConfig}
+                  isEnglish={isEnglish}
+                  onConfirm={() => {
+                    sendMove(origin, destination, host);
+                    setOrigin(NO_SELECT);
+                    setDestination(NO_SELECT);
+                  }}
+                  onCancel={() => setDestination(NO_SELECT)}
+                />
+              </Popover.Dropdown>
+            </Popover>
+          ) : (
+            cell
+          )}
+        </Grid.Col>
+      );
+    })
   );
 
   const divider = [
@@ -167,39 +205,9 @@ export default function GameBoard({
         >
           {isSpectator || gamePhase > 2 ? null : (
             <Center py="1em">
-              <Stack>
-                <Group align="center" direction="horizontal">
-                  <Button
-                    disabled={!isTurn || !(originSelected && destinationSelected)}
-                    onClick={() => {
-                      sendMove(origin, destination, host);
-                      setOrigin(NO_SELECT);
-                      setDestination(NO_SELECT);
-                    }}
-                  >
-                    {isEnglish
-                      ? isTurn
-                        ? 'Send move'
-                        : 'Opponent turn'
-                      : isTurn
-                      ? '送出移動'
-                      : '對手回合'}
-                  </Button>
-                  <Button
-                    variant="outline"
-                    color="red"
-                    onClick={() => {
-                      setOrigin(NO_SELECT);
-                      setDestination(NO_SELECT);
-                    }}
-                  >
-                    {isEnglish ? 'Reset move' : '重設移動'}
-                  </Button>
-                  <Button variant="filled" color="red" onClick={forfeit}>
-                    {isEnglish ? 'Forfeit' : '投降'}
-                  </Button>
-                </Group>
-              </Stack>
+              <Button variant="filled" color="red" onClick={forfeit}>
+                {isEnglish ? 'Forfeit' : '投降'}
+              </Button>
             </Center>
           )}
 

--- a/src/components/Instructions/Instructions.jsx
+++ b/src/components/Instructions/Instructions.jsx
@@ -114,8 +114,8 @@ const Instructions = ({ opened, onClose, gamePhase = 0, isEnglish = false }) => 
             {
               title: isEnglish ? 'Making Moves' : '移動棋子',
               description: isEnglish
-                ? 'Click on your piece to select it, then click on a valid destination. Click "Send move" to confirm.'
-                : '點擊您的棋子選擇它，然後點擊有效目的地。點擊「發送移動」確認。',
+                ? 'Click on your piece to select it, then click on a valid destination. Click "Send" to confirm.'
+                : '點擊您的棋子選擇它，然後點擊有效目的地。點擊「發送」確認。',
             },
             {
               title: isEnglish ? 'Piece Hierarchy' : '棋子階級',

--- a/src/components/MoveConfirmCard/MoveConfirmCard.jsx
+++ b/src/components/MoveConfirmCard/MoveConfirmCard.jsx
@@ -1,0 +1,78 @@
+import { Box, Text, Group, Button, Stack, Divider, ThemeIcon } from '@mantine/core';
+import PropTypes from 'prop-types';
+import { getPieceInfo } from 'data/pieceInfo';
+import { predictOutcome } from 'utils/predictOutcome';
+import { outcomeMessages } from '../PieceInfoPanel/PieceInfoPanel';
+
+function MiniPieceInfo({ piece, isEnglish }) {
+  const info = getPieceInfo(isEnglish)[piece.name];
+  if (!info) {
+    return null;
+  }
+  return (
+    <Group spacing={4} noWrap>
+      <ThemeIcon color="blue" variant="light" size="sm">
+        {info.icon}
+      </ThemeIcon>
+      <Text size="sm" fw={600}>
+        {info.title}
+      </Text>
+    </Group>
+  );
+}
+
+MiniPieceInfo.propTypes = {
+  piece: PropTypes.shape({ name: PropTypes.string.isRequired }).isRequired,
+  isEnglish: PropTypes.bool,
+};
+
+export default function MoveConfirmCard({
+  originPiece,
+  destinationPiece,
+  gameConfig = {},
+  isEnglish = false,
+  onConfirm,
+  onCancel,
+}) {
+  const outcome = predictOutcome(originPiece, destinationPiece, gameConfig);
+  const message = outcome && outcomeMessages[outcome.type];
+
+  return (
+    <Box sx={{ width: '14em' }}>
+      <Stack spacing="xs">
+        {destinationPiece ? (
+          <Group position="apart" noWrap>
+            <MiniPieceInfo piece={originPiece} isEnglish={isEnglish} />
+            <Text size="xs" c="dimmed">
+              {isEnglish ? 'vs' : '對'}
+            </Text>
+            <MiniPieceInfo piece={destinationPiece} isEnglish={isEnglish} />
+          </Group>
+        ) : null}
+        {message ? (
+          <Text size="sm" fw={600} color={message.color}>
+            {isEnglish ? message.text.en : message.text.zh}
+          </Text>
+        ) : null}
+        <Divider />
+        <Group position="apart" grow>
+          <Button size="md" onClick={onConfirm}>
+            {isEnglish ? 'Send' : '送出'}
+          </Button>
+          <Button size="md" variant="outline" color="red" onClick={onCancel}>
+            {isEnglish ? 'Cancel' : '取消'}
+          </Button>
+        </Group>
+      </Stack>
+    </Box>
+  );
+}
+
+MoveConfirmCard.propTypes = {
+  originPiece: PropTypes.object,
+  destinationPiece: PropTypes.object,
+  gameConfig: PropTypes.object,
+  isEnglish: PropTypes.bool,
+  onConfirm: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+};

--- a/src/components/MoveConfirmCard/index.jsx
+++ b/src/components/MoveConfirmCard/index.jsx
@@ -1,0 +1,3 @@
+import MoveConfirmCard from './MoveConfirmCard';
+
+export default MoveConfirmCard;

--- a/src/components/PieceInfoPanel/PieceInfoPanel.jsx
+++ b/src/components/PieceInfoPanel/PieceInfoPanel.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { getPieceInfo } from 'data/pieceInfo';
 import { predictOutcome } from 'utils/predictOutcome';
 
-const outcomeMessages = {
+export const outcomeMessages = {
   'both-die': {
     color: 'red',
     text: { en: 'Both pieces will be destroyed.', zh: '雙方棋子都會被摧毀。' },
@@ -17,6 +17,10 @@ const outcomeMessages = {
   'source-dies': {
     color: 'red',
     text: { en: 'Your piece will be destroyed.', zh: '您的棋子將被摧毀。' },
+  },
+  move: {
+    color: 'blue',
+    text: { en: 'Move to this tile.', zh: '移動至此空格。' },
   },
   unknown: {
     color: 'gray',

--- a/src/components/SelectablePosition.jsx
+++ b/src/components/SelectablePosition.jsx
@@ -1,7 +1,7 @@
-import { useEffect } from 'react';
+import { forwardRef, useEffect } from 'react';
 import Position from './Position';
 import { Box } from '@mantine/core';
-import { useHover } from '@mantine/hooks';
+import { useHover, useMergedRef } from '@mantine/hooks';
 import PropTypes from 'prop-types';
 
 const shadeMap = {
@@ -42,21 +42,25 @@ const getShadeColor = (
   return hovered ? hover : color;
 };
 
-export default function SelectablePosition({
-  row,
-  col,
-  piece,
-  onClick,
-  originSelected = false,
-  destinationSelected = false,
-  attackable = false,
-  movable = false,
-  isLastMove = false,
-  isEnglish,
-  disabled = false,
-  onHoverPiece,
-}) {
-  const { hovered, ref } = useHover();
+const SelectablePosition = forwardRef(function SelectablePosition(
+  {
+    row,
+    col,
+    piece,
+    onClick,
+    originSelected = false,
+    destinationSelected = false,
+    attackable = false,
+    movable = false,
+    isLastMove = false,
+    isEnglish,
+    disabled = false,
+    onHoverPiece,
+  },
+  ref
+) {
+  const { hovered, ref: hoverRef } = useHover();
+  const mergedRef = useMergedRef(hoverRef, ref);
   const shadeColor = getShadeColor(
     hovered,
     originSelected,
@@ -79,7 +83,7 @@ export default function SelectablePosition({
       sx={{
         cursor: disabled ? 'not-allowed' : 'pointer',
       }}
-      ref={ref}
+      ref={mergedRef}
       onClick={disabled ? undefined : onClick}
     >
       <Position
@@ -94,7 +98,7 @@ export default function SelectablePosition({
       />
     </Box>
   );
-}
+});
 
 SelectablePosition.propTypes = {
   row: PropTypes.number.isRequired,
@@ -110,3 +114,5 @@ SelectablePosition.propTypes = {
   disabled: PropTypes.bool.isRequired,
   onHoverPiece: PropTypes.func,
 };
+
+export default SelectablePosition;


### PR DESCRIPTION
Replaces the "Send move"/"Reset move" buttons at the top of the board with a small card anchored to the just-selected target tile, so confirming a move never requires scrolling back up on a tall board - especially painful on mobile. Shows the predicted combat outcome (or a plain "move here" prompt for a non-attack move) plus Confirm/Cancel actions; Cancel only clears the target, leaving the source selected so a different target can be picked. Anchored via a Mantine Popover with flip/shift and portal rendering so it stays fully visible near board edges and on narrow screens instead of getting clipped by the board's scroll container.

Also converts SelectablePosition to forwardRef, since Popover.Target clones its child and injects a ref directly - without forwardRef that ref silently resolved to null and the popover never anchored.

## Type of Change

- [X] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

## Screenshots

Please attach any design screenshots if UI update.
