### PR TITLE
fix(game): guard endGame's finalGame before revealing the board

### DIFF
--- a/src/contexts/GameContext.jsx
+++ b/src/contexts/GameContext.jsx
@@ -388,7 +388,12 @@ export const GameProvider = ({ children }) => {
       setGamePhase(3);
       setWinner(winnerIndex);
       setGameResults(gameStats);
-      setMyBoard(finalGame.board);
+      // finalGame is the server's unfogged view, revealing the board now
+      // that fog no longer needs to hide anything - guard it since it
+      // crosses the socket boundary from a separately-maintained payload
+      if (finalGame) {
+        setMyBoard(finalGame.board);
+      }
     });
 
     /** Server is returning an error message to the client */


### PR DESCRIPTION
# Description

Guards `endGame`'s `finalGame` before reading `.board`. One server emit site (forfeit, fixed in the companion backend PR) was omitting `finalGame`, throwing here and silently skipping the board reveal.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

## Screenshots

N/A — no UI/design change, just a defensive guard on an existing data flow.
