### PR TITLE
feat(auth): send verified ID tokens instead of raw uid claims

### DIFF
--- a/src/api/Game.js
+++ b/src/api/Game.js
@@ -12,8 +12,10 @@ export const getGameById = async (gameId) => {
     });
 };
 
-export const updateUidMap = async (gameId, playerName, uid) => {
-  return axios.post(`/games/${gameId}/${playerName}/${uid}`).catch((err) => {
+export const updateUidMap = async (gameId, playerName) => {
+  // the server derives the uid from the caller's own verified ID token
+  // (attached by the axios interceptor in index.jsx), not from this URL
+  return axios.post(`/games/${gameId}/${playerName}`).catch((err) => {
     console.error(err);
   });
 };

--- a/src/components/Lobby/Lobby.jsx
+++ b/src/components/Lobby/Lobby.jsx
@@ -53,18 +53,18 @@ const Lobby = () => {
     }
   };
 
-  const playerLeaveRoom = () => {
+  const playerLeaveRoom = async () => {
     socket.emit('playerLeaveRoom', {
       playerName,
-      uid: user?.uid || null,
+      idToken: user ? await user.getIdToken() : null,
       leaveRoomId: roomId,
     });
   };
 
-  const spectatorLeaveRoom = () => {
+  const spectatorLeaveRoom = async () => {
     socket.emit('spectatorLeaveRoom', {
       spectatorName,
-      uid: user?.uid || null,
+      idToken: user ? await user.getIdToken() : null,
       leaveRoomId: roomId,
     });
   };

--- a/src/components/Login/CreateAccount.jsx
+++ b/src/components/Login/CreateAccount.jsx
@@ -51,7 +51,7 @@ const CreateAccount = ({ setExistingAccount, setShowModal, roomId, playerName, i
         if (roomId) {
           // already joined a room
           addGame(user.uid, roomId);
-          updateUidMap(roomId, playerName, user.uid);
+          updateUidMap(roomId, playerName);
         }
         setShowModal(false);
       })

--- a/src/components/Login/EmailAndPasswordSignIn.jsx
+++ b/src/components/Login/EmailAndPasswordSignIn.jsx
@@ -36,7 +36,7 @@ const EmailAndPasswordSignIn = ({
         if (roomId) {
           // already joined a room
           addGame(user.uid, roomId);
-          updateUidMap(roomId, playerName, user.uid);
+          updateUidMap(roomId, playerName);
         }
         setShowModal(false);
       })

--- a/src/components/Login/Google.jsx
+++ b/src/components/Login/Google.jsx
@@ -22,7 +22,7 @@ const Google = ({ setShowModal, roomId, playerName }) => {
         if (roomId) {
           // already joined a room
           addGame(user.uid, roomId);
-          updateUidMap(roomId, playerName, user.uid);
+          updateUidMap(roomId, playerName);
         }
         console.info(`credential: ${JSON.stringify(credential)}`);
         console.info(`token: ${token}`);

--- a/src/components/Login/Phone.jsx
+++ b/src/components/Login/Phone.jsx
@@ -75,7 +75,7 @@ const Phone = ({ setShowModal, roomId, playerName, isEnglish }) => {
         if (roomId) {
           // already joined a room
           addGame(user.uid, roomId);
-          updateUidMap(roomId, playerName, user.uid);
+          updateUidMap(roomId, playerName);
         }
         console.info(`user: ${JSON.stringify(user)} user.phoneNumber: ${user.phoneNumber}`);
         setShowModal(false);

--- a/src/components/NavBar/NavBar.jsx
+++ b/src/components/NavBar/NavBar.jsx
@@ -50,7 +50,7 @@ const NavBar = () => {
     });
   };
 
-  const resetToLanding = () => {
+  const resetToLanding = async () => {
     if (gamePhase == 2) {
       setShowWarnModal(true);
       return;
@@ -89,7 +89,7 @@ const NavBar = () => {
     setErrors([]);
     socket.emit('playerLeaveRoom', {
       playerName,
-      uid: user?.uid || null,
+      idToken: user ? await user.getIdToken() : null,
       leaveRoomId: roomId,
     });
     setRoomId('');

--- a/src/contexts/GameContext.jsx
+++ b/src/contexts/GameContext.jsx
@@ -123,12 +123,12 @@ export const GameProvider = ({ children }) => {
   const [activeGames, setActiveGames] = useState([]);
 
   /** Attempts to reclaim a seat using a locally-stored session token if one
-   * exists for this game ID, otherwise (given a logged-in uid) falls back
-   * to asking the server to match the uid against the game's players.
-   * Returns false immediately if neither is available. */
-  const attemptRejoin = (gameId, uid = null) => {
+   * exists for this game ID, otherwise (given a logged-in Firebase user)
+   * falls back to asking the server to match a verified uid against the
+   * game's players. Returns false immediately if neither is available. */
+  const attemptRejoin = async (gameId, user = null) => {
     const session = loadSession(gameId);
-    if (!session && !uid) {
+    if (!session && !user) {
       setRejoining(false);
       return false;
     }
@@ -140,19 +140,19 @@ export const GameProvider = ({ children }) => {
       gameId,
       playerName: session?.playerName,
       token: session?.token,
-      uid,
+      idToken: user ? await user.getIdToken() : null,
     });
     return true;
   };
 
   /** Asks the server which of the logged-in user's games are still ongoing
    * and worth showing a "rejoin" prompt for. Results land in activeGames. */
-  const checkActiveGames = (uid) => {
-    if (!uid) {
+  const checkActiveGames = async (user) => {
+    if (!user) {
       setActiveGames([]);
       return;
     }
-    socket.emit('getMyActiveGames', { uid });
+    socket.emit('getMyActiveGames', { idToken: await user.getIdToken() });
   };
 
   const gameState = {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter } from 'react-router-dom';
 import axios from 'axios';
+import { getAuth } from 'firebase/auth';
 
 import './index.css';
 import { GameProvider } from 'contexts/GameContext';
@@ -13,6 +14,18 @@ import { CustomFonts } from './CustomFonts';
 import theme, { other } from './theme';
 
 axios.defaults.baseURL = `${import.meta.env.VITE_API}`;
+
+// attaches the current user's Firebase ID token to every REST call, so the
+// server can verify who's actually asking instead of trusting whatever uid
+// a request claims - a no-op when nobody's logged in (anonymous play is
+// allowed throughout this app)
+axios.interceptors.request.use(async (config) => {
+  const user = getAuth().currentUser;
+  if (user) {
+    config.headers.Authorization = `Bearer ${await user.getIdToken()}`;
+  }
+  return config;
+});
 
 ReactDOM.render(
   <React.StrictMode>

--- a/src/views/Game.jsx
+++ b/src/views/Game.jsx
@@ -14,7 +14,7 @@ import { Container, Flex, Center, Title, Loader } from '@mantine/core';
 
 const Game = () => {
   let { roomId } = useParams();
-  const uid = useFirebaseAuth()?.uid;
+  const user = useFirebaseAuth();
   const {
     socket,
     spectatorName: { spectatorName },
@@ -53,11 +53,11 @@ const Game = () => {
 
   /** On mount (or a hard reload), silently try to reclaim a seat using a
    * locally-stored session - or, on a device with none but a logged-in
-   * uid, ask the server to match that uid against the game's players -
-   * before falling back to the normal join form. */
+   * user, ask the server to match a verified uid against the game's
+   * players - before falling back to the normal join form. */
   useEffect(() => {
     if (roomId && !joinedGame && playerList.length === 0) {
-      attemptRejoin(roomId, uid);
+      attemptRejoin(roomId, user);
     }
     // only re-run when the room in the URL changes, not on every state update
   }, [roomId]);
@@ -86,12 +86,12 @@ const Game = () => {
         }
       : null;
 
-  const playerMakeMove = (source, target, host) => {
+  const playerMakeMove = async (source, target, host) => {
     if (source.length && target.length) {
       // if target is in successors, make move
       socket.emit('playerMakeMove', {
         playerName,
-        uid,
+        idToken: user ? await user.getIdToken() : null,
         room: roomId,
         turn: clientTurn,
         pendingMove: {
@@ -110,9 +110,10 @@ const Game = () => {
   const playerForfeit = (e) => {
     console.info('Game forfeitted!');
     e.preventDefault();
+    // the server derives winnerId from the *other* player's already-
+    // recorded uid, not from anything the forfeiting client sends
     socket.emit('playerForfeit', {
       playerName,
-      uid,
       room: roomId,
     });
   };

--- a/src/views/Menu.jsx
+++ b/src/views/Menu.jsx
@@ -46,7 +46,7 @@ function Menu({ joinedRoom = false, urlRoomId = '' }) {
   // notably covers logging in from a device with no local session for them
   useEffect(() => {
     if (!joinedRoom && user?.uid) {
-      checkActiveGames(user.uid);
+      checkActiveGames(user);
     }
   }, [joinedRoom, user?.uid]);
 
@@ -75,12 +75,12 @@ function Menu({ joinedRoom = false, urlRoomId = '' }) {
   const linkStyle = { color: 'white' };
 
   /** Tell the server to create a new game */
-  const createNewGame = (name, vsAi, aiSettings, rules) => {
+  const createNewGame = async (name, vsAi, aiSettings, rules) => {
     if (name) {
       setPlayerName(name);
       socket.emit('hostCreateNewGame', {
         playerName: name,
-        hostId: user?.uid || null,
+        idToken: user ? await user.getIdToken() : null,
         // vsAi games skip the Lobby (where a human game's host would
         // otherwise set these), so rules must be sent at creation time
         gameConfig: vsAi ? { opponentType: 'ai', aiSettings, ...rules } : undefined,
@@ -96,13 +96,13 @@ function Menu({ joinedRoom = false, urlRoomId = '' }) {
   };
 
   /** Attempt to join a room by game ID */
-  const playerJoinGame = (name, roomId) => {
+  const playerJoinGame = async (name, roomId) => {
     if (name && roomId) {
-      console.info(`Attempting to JOIN game ${roomId} as ${name} with clientId ${user?.uid}`);
+      console.info(`Attempting to JOIN game ${roomId} as ${name}`);
       setPlayerName(name);
       socket.emit('playerJoinRoom', {
         playerName: name,
-        clientId: user?.uid || null,
+        idToken: user ? await user.getIdToken() : null,
         joinRoomId: roomId,
       });
       setRoomId(roomId);
@@ -117,14 +117,12 @@ function Menu({ joinedRoom = false, urlRoomId = '' }) {
   };
 
   /** Attempt to spectate a room by game ID */
-  const spectateGame = (spectatorName, roomId) => {
+  const spectateGame = async (spectatorName, roomId) => {
     if (playerName && roomId) {
-      console.info(
-        `Attempting to SPECTATE game ${roomId} as ${spectatorName} with clientId ${user?.uid}`
-      );
+      console.info(`Attempting to SPECTATE game ${roomId} as ${spectatorName}`);
       socket.emit('spectateRoom', {
         spectatorName,
-        clientId: user?.uid || null,
+        idToken: user ? await user.getIdToken() : null,
         joinRoomId: roomId,
       });
       setRoomId(roomId);


### PR DESCRIPTION
# Description

Companion to the backend's Firebase Admin SDK change. Sends verified ID tokens (via an axios interceptor for REST, and per-emit for sockets) instead of raw `uid`/`hostId`/`clientId` claims, so the server can verify caller identity instead of trusting client input.

## Type of Change

- [x] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

## Screenshots

N/A — no UI change, just what data accompanies existing requests.

Verified manually: anonymous play (join/setup/gameplay) still works end-to-end; lint clean. Needs the companion backend PR deployed alongside it — backward compatible either way, since a client sending no `idToken` is treated as anonymous, same as today.
