### PR TITLE
fix(piece): prevent accidental text selection on piece labels

### DIFF
--- a/src/components/Piece/index.jsx
+++ b/src/components/Piece/index.jsx
@@ -12,6 +12,11 @@ export default function Piece({ name, affiliation, isEnglish }) {
         borderRadius: '10%',
         boxShadow: theme.shadows.sm,
         writingMode: 'horizontal-tb',
+        // pieces are clicked/dragged rapidly during play and setup - without
+        // this, a fast double-click or a drag that starts on the label text
+        // selects it like ordinary page text instead of acting on the piece
+        userSelect: 'none',
+        WebkitUserSelect: 'none',
         width: theme.other.pieceSizing.md.width,
         height: theme.other.pieceSizing.md.height,
         fontSize: theme.other.pieceSizing.md.fontSize,


### PR DESCRIPTION
# Description

Rapid clicking/dragging on a piece (during play or setup) could select its label text like ordinary page text. Fixed in `Piece/index.jsx`, the single shared component rendering a piece everywhere one appears — one fix covers the live board, setup board, and dead-pieces list.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

## Screenshots

N/A — CSS-only behavioral fix, no visual change.
