### PR TITLE
fix(game): re-register the seat with the server on every socket reconnect

### DIFF
--- a/src/contexts/GameContext.jsx
+++ b/src/contexts/GameContext.jsx
@@ -210,6 +210,19 @@ export const GameProvider = ({ children }) => {
     socket.on('connect', () => {
       console.info(`SocketID: ${socket.id}`);
       console.info(`Connected: ${socket.connected}`);
+      // the underlying transport can reconnect under a new socket.id after
+      // a network drop or server restart without the page ever reloading -
+      // React state (joinedGame, playerList, ...) survives that untouched,
+      // so Game.jsx's own mount-time rejoin effect never re-fires, but the
+      // server's in-memory socketSeatRegistry (keyed by socket.id, proof
+      // that a later move/forfeit/etc. actually belongs to this seat) does
+      // NOT survive it. Silently re-establishing the seat here - a no-op
+      // on the very first connect, since roomId is still empty then - is
+      // what prevents "You do not have permission to act as X" on the
+      // first action after a reconnect.
+      if (roomId) {
+        attemptRejoin(roomId);
+      }
     });
 
     /** Server has created a new game, only host receives this message */


### PR DESCRIPTION
# Description

Fixes "You do not have permission to act as X" appearing after any socket-level reconnect (network drop, server restart) that doesn't involve a full page reload. React state survives such a reconnect untouched, so the existing mount-time rejoin effect never re-fires — but the server's in-memory seat registry, keyed by socket.id, does not survive it. `socket.on('connect')` now re-registers the seat whenever a room is already known.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

## Screenshots

N/A — background reconnection behavior, no UI change (confirmed invisible to the player: the rejoining spinner only shows when `playerList` is empty, which it never is on a real reconnect).

Verified live: restarted the backend mid-game (forces a new socket.id + wiped server-side registry) and confirmed a move sent immediately after the automatic reconnect now succeeds, where it previously failed with the permission error. Companion backend PR (`fix-reconnect-token-blocking`) removes a related edge case in the same rejoin path.
