### PR TITLE
chore(game): close the socket on HMR dispose to prevent dev-session buildup

### DIFF
--- a/src/contexts/GameContext.jsx
+++ b/src/contexts/GameContext.jsx
@@ -9,6 +9,19 @@ const socket = io(import.meta.env.VITE_API);
 // const socket = io('localhost:4000');
 // const socket = io('https://luzhanqi.herokuapp.com/');
 
+// dev-only: without this, every Vite hot-reload of this module (or
+// anything it transitively imports) opens a brand new socket connection on
+// top of the old one, which never gets closed - a long dev session with
+// many edits ends up with dozens of live sockets/listeners piling up in
+// the same tab, which is real, cumulative overhead the app itself doesn't
+// have (import.meta.hot doesn't exist in a production build, so this is a
+// no-op there)
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    socket.close();
+  });
+}
+
 export const GameContext = createContext({});
 
 const sessionKey = (gameId) => `luzhanqi:session:${gameId}`;


### PR DESCRIPTION
# Description

Dev-only fix: the socket connection is created at module scope with no Vite HMR cleanup — every edit hot-swapping this module opened a new connection on top of the old one. Over a long dev session this accumulates real overhead in the browser tab. `import.meta.hot.dispose()` closes the stale socket; it's a no-op in production, where `import.meta.hot` doesn't exist.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

## Screenshots

N/A — dev-tooling change, no UI/runtime behavior change in production.

Prompted by investigating a "page slowing down" report: idle-state testing found zero background loops or runaway activity in the app itself (instrumented both the menu and live gameplay board, 0 console/rAF/DOM-mutation activity over ~20s idle), but the dev server had accumulated 143 logged connections with no corresponding disconnect logging to rule a leak in or out. This closes the most plausible gap regardless.
