### PR TITLE
perf(game): batch socket handler state updates to cut re-renders per event

### DIFF
--- a/src/contexts/GameContext.jsx
+++ b/src/contexts/GameContext.jsx
@@ -1,4 +1,5 @@
 import React, { createContext, useState, useEffect, useRef } from 'react';
+import { unstable_batchedUpdates } from 'react-dom';
 import { useNavigate } from 'react-router';
 import { io } from 'socket.io-client';
 import { toast } from 'react-toastify';
@@ -207,7 +208,17 @@ export const GameProvider = ({ children }) => {
    * Function on second parameter handles socket call parameters
    */
   useEffect(() => {
-    socket.on('connect', () => {
+    // socket.io callbacks fire outside React's event system, so React 17
+    // won't auto-batch the setState calls inside them - most handlers below
+    // call several setters per event (e.g. playerMadeMove sets turn, board,
+    // deadPieces, and lastMove), which without this wrapper means up to one
+    // full re-render of every GameContext consumer per setState call instead
+    // of one per event. Wrapping keeps each event to a single re-render.
+    const on = (event, handler) => {
+      socket.on(event, (...args) => unstable_batchedUpdates(() => handler(...args)));
+    };
+
+    on('connect', () => {
       console.info(`SocketID: ${socket.id}`);
       console.info(`Connected: ${socket.connected}`);
       // the underlying transport can reconnect under a new socket.id after
@@ -226,22 +237,19 @@ export const GameProvider = ({ children }) => {
     });
 
     /** Server has created a new game, only host receives this message */
-    socket.on(
-      'newGameCreated',
-      ({ gameId, joinCode: newJoinCode, mySocketId, players, phase, token }) => {
-        const serverRoomId = gameId;
-        console.info(`GameID: ${serverRoomId}, SocketID: ${mySocketId}`);
-        setRoomId(serverRoomId);
-        setJoinCode(newJoinCode || '');
-        setPlayerList(players);
-        saveSession(serverRoomId, playerNameRef.current, token);
-        if (typeof phase === 'number') setGamePhase(phase);
-        navigate(`/game/${serverRoomId}`);
-      }
-    );
+    on('newGameCreated', ({ gameId, joinCode: newJoinCode, mySocketId, players, phase, token }) => {
+      const serverRoomId = gameId;
+      console.info(`GameID: ${serverRoomId}, SocketID: ${mySocketId}`);
+      setRoomId(serverRoomId);
+      setJoinCode(newJoinCode || '');
+      setPlayerList(players);
+      saveSession(serverRoomId, playerNameRef.current, token);
+      if (typeof phase === 'number') setGamePhase(phase);
+      navigate(`/game/${serverRoomId}`);
+    });
 
     /** Server is telling all clients the game has started  */
-    socket.on('beginNewGame', ({ mySocketId, roomId, turn }) => {
+    on('beginNewGame', ({ mySocketId, roomId, turn }) => {
       console.info(`Starting game for room ${roomId} on socket ${mySocketId}`);
       // setDisplayTimer(true);
       setClientTurn(turn);
@@ -249,14 +257,14 @@ export const GameProvider = ({ children }) => {
     });
 
     /** Server is telling all clients someone has joined the room */
-    socket.on('playerJoinedRoom', ({ playerName: returnedPlayerName, players, spectators }) => {
+    on('playerJoinedRoom', ({ playerName: returnedPlayerName, players, spectators }) => {
       console.info(`${returnedPlayerName} has joined the room!`);
       setPlayerList(players);
       if (Array.isArray(spectators)) setSpectatorList(spectators);
     });
 
     /** Server is telling this socket that it has joined a room */
-    socket.on('youHaveJoinedTheRoom', (data) => {
+    on('youHaveJoinedTheRoom', (data) => {
       setJoinedGame(true);
       // setPlayerList(data.players);
       const joinedRoomId = data.joinRoomId || roomId;
@@ -269,7 +277,7 @@ export const GameProvider = ({ children }) => {
 
     /** A stored session, or (from a device with none) a logged-in uid
      * matching a seat, successfully reclaimed a seat after a disconnect */
-    socket.on('youHaveRejoinedTheRoom', (data) => {
+    on('youHaveRejoinedTheRoom', (data) => {
       setRejoining(false);
       setJoinedGame(true);
       setPlayerName(data.playerName);
@@ -295,27 +303,27 @@ export const GameProvider = ({ children }) => {
     });
 
     /** The stored session token was rejected - fall back to the normal join form */
-    socket.on('rejoinFailed', (data) => {
+    on('rejoinFailed', (data) => {
       setRejoining(false);
       clearSession(data.gameId);
     });
 
     /** An opponent's socket dropped - their seat is still reserved, they may reconnect */
-    socket.on('playerDisconnected', ({ playerName: droppedName }) => {
+    on('playerDisconnected', ({ playerName: droppedName }) => {
       setDisconnectedPlayer(droppedName);
     });
 
-    socket.on('playerReconnected', ({ playerName: returnedName }) => {
+    on('playerReconnected', ({ playerName: returnedName }) => {
       setDisconnectedPlayer((current) => (current === returnedName ? null : current));
     });
 
     /** Server's answer to checkActiveGames - games tied to this account
      * that are still ongoing and worth prompting the user to rejoin */
-    socket.on('myActiveGames', (games) => {
+    on('myActiveGames', (games) => {
       setActiveGames(Array.isArray(games) ? games : []);
     });
 
-    socket.on('playerLeftRoom', ({ playerName: returnedPlayerName, players }) => {
+    on('playerLeftRoom', ({ playerName: returnedPlayerName, players }) => {
       console.info(`${returnedPlayerName} has left the room!`);
       setPlayerList(players);
       setClientTurn(-1);
@@ -323,13 +331,13 @@ export const GameProvider = ({ children }) => {
       setSubmittedSide(false);
     });
 
-    socket.on('spectatorLeftRoom', ({ spectatorName: returnedSpectatorName, spectators }) => {
+    on('spectatorLeftRoom', ({ spectatorName: returnedSpectatorName, spectators }) => {
       console.info(`${returnedSpectatorName} has left the room!`);
       setSpectatorList(spectators);
     });
 
     /** Server is telling this socket that it has left a room */
-    socket.on('youHaveLeftTheRoom', () => {
+    on('youHaveLeftTheRoom', () => {
       setJoinedGame(false);
       setPlayerList([]);
       navigate(`/`);
@@ -339,17 +347,14 @@ export const GameProvider = ({ children }) => {
     });
 
     /** Server is telling all clients someone is spectating the room */
-    socket.on(
-      'spectatorJoinedRoom',
-      ({ spectatorName: returnedSpectatorName, spectators, players }) => {
-        console.info(`${returnedSpectatorName} has joined the room!`);
-        setPlayerList(players);
-        setSpectatorList(spectators);
-      }
-    );
+    on('spectatorJoinedRoom', ({ spectatorName: returnedSpectatorName, spectators, players }) => {
+      console.info(`${returnedSpectatorName} has joined the room!`);
+      setPlayerList(players);
+      setSpectatorList(spectators);
+    });
 
     /** Server is telling this socket that it has joined a room */
-    socket.on('youAreSpectatingTheRoom', (data) => {
+    on('youAreSpectatingTheRoom', (data) => {
       setJoinedGame(true);
       const joinedRoomId = data?.gameId || roomId;
       setRoomId(joinedRoomId);
@@ -358,7 +363,7 @@ export const GameProvider = ({ children }) => {
     });
 
     /** Server is sending the starting board with all placed pieces */
-    socket.on('boardSet', (game) => {
+    on('boardSet', (game) => {
       setMyBoard(game.board);
       setGamePhase(2);
       setLastMove(null);
@@ -368,16 +373,16 @@ export const GameProvider = ({ children }) => {
       if (game.config) setGameConfig(game.config);
     });
 
-    socket.on('halfBoardReceived', () => {
+    on('halfBoardReceived', () => {
       setSubmittedSide(true);
     });
 
-    socket.on('pieceSelected', (pieces) => {
+    on('pieceSelected', (pieces) => {
       setSuccessors(pieces);
     });
 
     /** Server is telling all clients a move has been made */
-    socket.on('playerMadeMove', ({ turn, board, deadPieces, moves }) => {
+    on('playerMadeMove', ({ turn, board, deadPieces, moves }) => {
       setClientTurn(turn);
       setMyBoard(board);
       setMyDeadPieces(deadPieces);
@@ -389,7 +394,7 @@ export const GameProvider = ({ children }) => {
     /** Server is telling both players (and spectators) that a field marshal
      * died on the move that just resolved - notable since the loser's flag
      * becomes revealed to their opponent once this happens */
-    socket.on('fieldMarshallDown', (fallen) => {
+    on('fieldMarshallDown', (fallen) => {
       fallen.forEach(({ playerName: fallenPlayerName }) => {
         const isMine = fallenPlayerName === playerNameRef.current;
         const message = isEnglishRef.current
@@ -404,7 +409,7 @@ export const GameProvider = ({ children }) => {
     });
 
     /** Server is telling all clients the game has ended */
-    socket.on('endGame', ({ winnerIndex, gameStats, finalGame }) => {
+    on('endGame', ({ winnerIndex, gameStats, finalGame }) => {
       setGamePhase(3);
       setWinner(winnerIndex);
       setGameResults(gameStats);
@@ -420,7 +425,7 @@ export const GameProvider = ({ children }) => {
      * gameplay, also resync with the server - an error here can mean a
      * client-side optimistic update (see Game.jsx's playerMakeMove) guessed
      * wrong and is now showing a stale/incorrect board. */
-    socket.on('error', (errMsg) => {
+    on('error', (errMsg) => {
       pushErrors(errMsg);
       if (gamePhaseRef.current === 2) {
         attemptRejoin(roomId);


### PR DESCRIPTION
React 17 doesn't auto-batch setState calls made outside its own event system, and socket.io callbacks run outside it - so every multi-setState handler here (playerMadeMove alone sets 4 pieces of state) was forcing one full re-render of every GameContext consumer per setState call instead of one per event. Wrapping registration in unstable_batchedUpdates collapses that back to a single re-render.

## Type of Change

- [ ] New feature
- [X] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

## Screenshots

Please attach any design screenshots if UI update.
