### PR TITLE
fix(menu): stop language toggle from resetting in-progress form input

### DIFF
--- a/src/views/Menu.jsx
+++ b/src/views/Menu.jsx
@@ -18,11 +18,6 @@ const cardStyle = {
   boxShadow: '0.3em 0.3em 0.1em #69a2ff',
 };
 
-/** Defined outside Menu (a stable component identity, not recreated on
- * every Menu render) so toggling isEnglish or any other Menu-level state
- * change doesn't unmount/remount this form - that used to wipe out
- * whatever the user had already typed and fall back to the stale
- * initialValues. */
 function CreateForm({ playerName, isEnglish, onSubmit }) {
   const createForm = useForm({
     initialValues: {
@@ -295,7 +290,6 @@ function Menu({ joinedRoom = false, urlRoomId = '' }) {
     }
   });
 
-  // only on the real landing page (not the in-game "join" fallback form),
   // ask whether this logged-in account has other games worth rejoining -
   // notably covers logging in from a device with no local session for them
   useEffect(() => {

--- a/src/views/Menu.jsx
+++ b/src/views/Menu.jsx
@@ -10,6 +10,260 @@ import { Title } from '@mantine/core';
 import HelpButton from '../components/HelpButton';
 import { archiveGame } from 'api/User';
 
+const cardStyle = {
+  backgroundColor: '#adcdff',
+  padding: '1em',
+  width: '20em',
+  borderRadius: '0.5em',
+  boxShadow: '0.3em 0.3em 0.1em #69a2ff',
+};
+
+/** Defined outside Menu (a stable component identity, not recreated on
+ * every Menu render) so toggling isEnglish or any other Menu-level state
+ * change doesn't unmount/remount this form - that used to wipe out
+ * whatever the user had already typed and fall back to the stale
+ * initialValues. */
+function CreateForm({ playerName, isEnglish, onSubmit }) {
+  const createForm = useForm({
+    initialValues: {
+      playerName,
+      vsAi: false,
+      // defaults must match DEFAULT_AI_WEIGHTS in the backend's aiConstants.ts
+      randomness: 1.5,
+      positionalDrive: 0.15,
+      caution: 0.5,
+      aggression: 1,
+      // rule variants - defaults match createGame's resolvedConfig in the backend
+      fogOfWar: true,
+      landminesSurvive: false,
+      flyingBombs: false,
+      captureTheFlag: false,
+    },
+  });
+  const vsAi = createForm.values.vsAi;
+
+  return (
+    <Container style={cardStyle}>
+      <Title order={3}>{isEnglish ? 'Host a New Game' : '建立新遊戲'}</Title>
+      <form onSubmit={createForm.onSubmit(onSubmit)}>
+        <Tabs defaultValue="basic" keepMounted={false}>
+          <Tabs.List>
+            <Tabs.Tab value="basic">{isEnglish ? 'Basic' : '基本'}</Tabs.Tab>
+            {vsAi ? <Tabs.Tab value="rules">{isEnglish ? 'Rules' : '規則'}</Tabs.Tab> : null}
+            {vsAi ? <Tabs.Tab value="advanced">{isEnglish ? 'Advanced' : '進階'}</Tabs.Tab> : null}
+          </Tabs.List>
+
+          <Tabs.Panel value="basic" pt="sm">
+            <TextInput
+              label={isEnglish ? 'Player name:' : '玩家名稱：'}
+              placeholder="Ex. Ian"
+              {...createForm.getInputProps('playerName')}
+            />
+            <Checkbox
+              mt="md"
+              label={isEnglish ? 'Play against the computer' : '與電腦對戰'}
+              {...createForm.getInputProps('vsAi', { type: 'checkbox' })}
+            />
+          </Tabs.Panel>
+
+          {vsAi ? (
+            <Tabs.Panel value="rules" pt="sm">
+              <Checkbox
+                mt="md"
+                label={isEnglish ? 'Enable fog of war' : '啟用戰爭迷霧'}
+                {...createForm.getInputProps('fogOfWar', { type: 'checkbox' })}
+              />
+              <Checkbox
+                mt="sm"
+                label={
+                  isEnglish
+                    ? 'Landmines survive (only the attacker dies)'
+                    : '地雷不會被摧毀（只有攻擊方陣亡）'
+                }
+                {...createForm.getInputProps('landminesSurvive', { type: 'checkbox' })}
+              />
+              <Checkbox
+                mt="sm"
+                label={
+                  isEnglish
+                    ? 'Flying bombs (bombs move like the Engineer)'
+                    : '飛彈（炸彈可像工兵一樣轉彎移動）'
+                }
+                {...createForm.getInputProps('flyingBombs', { type: 'checkbox' })}
+              />
+              <Checkbox
+                mt="sm"
+                label={
+                  isEnglish
+                    ? 'Capture the flag (carry it back to your HQ to win)'
+                    : '奪旗規則（需將軍旗帶回己方大本營才能獲勝）'
+                }
+                {...createForm.getInputProps('captureTheFlag', { type: 'checkbox' })}
+              />
+            </Tabs.Panel>
+          ) : null}
+
+          {vsAi ? (
+            <Tabs.Panel value="advanced" pt="sm">
+              <Text size="xs" c="dimmed" mb="sm">
+                {isEnglish ? 'Tune how the computer opponent plays.' : '調整電腦對手的下棋方式。'}
+              </Text>
+              <Text size="sm">{isEnglish ? 'Randomness' : '隨機性'}</Text>
+              <Text size="xs" c="dimmed">
+                {isEnglish ? 'How unpredictable its moves are.' : '棋步的不可預測程度。'}
+              </Text>
+              <Slider
+                min={0}
+                max={3}
+                step={0.1}
+                label={(v) => v.toFixed(1)}
+                value={createForm.values.randomness}
+                onChange={(v) => createForm.setFieldValue('randomness', v)}
+              />
+              <Text size="sm" mt="md">
+                {isEnglish ? 'Positional drive' : '進攻傾向'}
+              </Text>
+              <Text size="xs" c="dimmed">
+                {isEnglish
+                  ? 'How much it favors advancing toward your side over holding position.'
+                  : '相較於固守陣地，電腦有多傾向向前推進。'}
+              </Text>
+              <Slider
+                min={0}
+                max={0.5}
+                step={0.01}
+                label={(v) => v.toFixed(2)}
+                value={createForm.values.positionalDrive}
+                onChange={(v) => createForm.setFieldValue('positionalDrive', v)}
+              />
+              <Text size="sm" mt="md">
+                {isEnglish ? 'Caution' : '謹慎程度'}
+              </Text>
+              <Text size="xs" c="dimmed">
+                {isEnglish
+                  ? 'How strongly it avoids exposing valuable pieces to risk.'
+                  : '電腦避免讓重要棋子暴露於風險中的程度。'}
+              </Text>
+              <Slider
+                min={0}
+                max={2}
+                step={0.1}
+                label={(v) => v.toFixed(1)}
+                value={createForm.values.caution}
+                onChange={(v) => createForm.setFieldValue('caution', v)}
+              />
+              <Text size="sm" mt="md">
+                {isEnglish ? 'Aggression' : '侵略性'}
+              </Text>
+              <Text size="xs" c="dimmed">
+                {isEnglish
+                  ? 'How much extra value it places on capturing pieces.'
+                  : '電腦對俘獲棋子賦予多少額外價值。'}
+              </Text>
+              <Slider
+                min={0}
+                max={3}
+                step={0.1}
+                label={(v) => v.toFixed(1)}
+                value={createForm.values.aggression}
+                onChange={(v) => createForm.setFieldValue('aggression', v)}
+              />
+            </Tabs.Panel>
+          ) : null}
+        </Tabs>
+        <br />
+        <Button variant="info" type="submit">
+          {isEnglish ? 'Create Match' : '建立對局'}
+        </Button>
+      </form>
+    </Container>
+  );
+}
+
+CreateForm.propTypes = {
+  playerName: PropTypes.string.isRequired,
+  isEnglish: PropTypes.bool.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+};
+
+function JoinForm({ playerName, urlRoomId, isEnglish, onSubmit }) {
+  const joinForm = useForm({
+    initialValues: {
+      // these keys must match the input keys for handlejoinSubmit
+      playerName,
+      roomId: urlRoomId,
+    },
+  });
+  return (
+    <Container style={cardStyle}>
+      <Title order={3}>{isEnglish ? 'Join a Game' : '加入遊戲'}</Title>
+      <form onSubmit={joinForm.onSubmit(onSubmit)}>
+        <TextInput
+          label={isEnglish ? 'Player name:' : '玩家名稱：'}
+          placeholder="Ex. Ian"
+          {...joinForm.getInputProps('playerName')}
+        />
+        <TextInput
+          label={isEnglish ? 'Join game:' : '加入代碼：'}
+          placeholder="Ex. 7K4X2P"
+          {...joinForm.getInputProps('roomId')}
+          disabled={!!urlRoomId}
+        />
+        <br />
+        <Button variant="info" type="submit">
+          {isEnglish ? 'Submit' : '送出'}
+        </Button>
+      </form>
+    </Container>
+  );
+}
+
+JoinForm.propTypes = {
+  playerName: PropTypes.string.isRequired,
+  urlRoomId: PropTypes.string,
+  isEnglish: PropTypes.bool.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+};
+
+function SpectateForm({ spectatorName, urlRoomId, isEnglish, onSubmit }) {
+  const spectateForm = useForm({
+    initialValues: {
+      // these keys must match the input keys for handleSpectateSubmit
+      spectatorName,
+      roomId: urlRoomId,
+    },
+  });
+  return (
+    <Container style={cardStyle}>
+      <Title order={3}>{isEnglish ? 'Spectate a Game' : '觀戰遊戲'}</Title>
+      <form onSubmit={spectateForm.onSubmit(onSubmit)}>
+        <TextInput
+          label={isEnglish ? 'Spectator name:' : '觀眾名稱：'}
+          placeholder="Ex. Ian"
+          {...spectateForm.getInputProps('spectatorName')}
+        />
+        <TextInput
+          label={isEnglish ? 'Spectate game:' : '觀戰代碼：'}
+          placeholder="Ex. 7K4X2P"
+          {...spectateForm.getInputProps('roomId')}
+          disabled={!!urlRoomId}
+        />
+        <br />
+        <Button variant="info" type="submit">
+          {isEnglish ? 'Submit' : '送出'}
+        </Button>
+      </form>
+    </Container>
+  );
+}
+
+SpectateForm.propTypes = {
+  spectatorName: PropTypes.string.isRequired,
+  urlRoomId: PropTypes.string,
+  isEnglish: PropTypes.bool.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+};
+
 function Menu({ joinedRoom = false, urlRoomId = '' }) {
   const {
     socket,
@@ -60,13 +314,6 @@ function Menu({ joinedRoom = false, urlRoomId = '' }) {
     display: 'flex',
     flexDirection: 'column',
     gap: '0.5em 0.5em',
-  };
-  const cardStyle = {
-    backgroundColor: '#adcdff',
-    padding: '1em',
-    width: '20em',
-    borderRadius: '0.5em',
-    boxShadow: '0.3em 0.3em 0.1em #69a2ff',
   };
   const cardContentStyle = {
     display: 'flex',
@@ -172,233 +419,6 @@ function Menu({ joinedRoom = false, urlRoomId = '' }) {
     spectateGame(spectatorName, roomId);
   };
 
-  const CreateForm = () => {
-    const createForm = useForm({
-      initialValues: {
-        playerName,
-        vsAi: false,
-        // defaults must match DEFAULT_AI_WEIGHTS in the backend's aiConstants.ts
-        randomness: 1.5,
-        positionalDrive: 0.15,
-        caution: 0.5,
-        aggression: 1,
-        // rule variants - defaults match createGame's resolvedConfig in the backend
-        fogOfWar: true,
-        landminesSurvive: false,
-        flyingBombs: false,
-        captureTheFlag: false,
-      },
-    });
-    const vsAi = createForm.values.vsAi;
-
-    return (
-      <Container style={cardStyle}>
-        <Title order={3}>{isEnglish ? 'Host a New Game' : '建立新遊戲'}</Title>
-        <form onSubmit={createForm.onSubmit(handleCreateSubmit)}>
-          <Tabs defaultValue="basic" keepMounted={false}>
-            <Tabs.List>
-              <Tabs.Tab value="basic">{isEnglish ? 'Basic' : '基本'}</Tabs.Tab>
-              {vsAi ? <Tabs.Tab value="rules">{isEnglish ? 'Rules' : '規則'}</Tabs.Tab> : null}
-              {vsAi ? (
-                <Tabs.Tab value="advanced">{isEnglish ? 'Advanced' : '進階'}</Tabs.Tab>
-              ) : null}
-            </Tabs.List>
-
-            <Tabs.Panel value="basic" pt="sm">
-              <TextInput
-                label={isEnglish ? 'Player name:' : '玩家名稱：'}
-                placeholder="Ex. Ian"
-                {...createForm.getInputProps('playerName')}
-              />
-              <Checkbox
-                mt="md"
-                label={isEnglish ? 'Play against the computer' : '與電腦對戰'}
-                {...createForm.getInputProps('vsAi', { type: 'checkbox' })}
-              />
-            </Tabs.Panel>
-
-            {vsAi ? (
-              <Tabs.Panel value="rules" pt="sm">
-                <Checkbox
-                  mt="md"
-                  label={isEnglish ? 'Enable fog of war' : '啟用戰爭迷霧'}
-                  {...createForm.getInputProps('fogOfWar', { type: 'checkbox' })}
-                />
-                <Checkbox
-                  mt="sm"
-                  label={
-                    isEnglish
-                      ? 'Landmines survive (only the attacker dies)'
-                      : '地雷不會被摧毀（只有攻擊方陣亡）'
-                  }
-                  {...createForm.getInputProps('landminesSurvive', { type: 'checkbox' })}
-                />
-                <Checkbox
-                  mt="sm"
-                  label={
-                    isEnglish
-                      ? 'Flying bombs (bombs move like the Engineer)'
-                      : '飛彈（炸彈可像工兵一樣轉彎移動）'
-                  }
-                  {...createForm.getInputProps('flyingBombs', { type: 'checkbox' })}
-                />
-                <Checkbox
-                  mt="sm"
-                  label={
-                    isEnglish
-                      ? 'Capture the flag (carry it back to your HQ to win)'
-                      : '奪旗規則（需將軍旗帶回己方大本營才能獲勝）'
-                  }
-                  {...createForm.getInputProps('captureTheFlag', { type: 'checkbox' })}
-                />
-              </Tabs.Panel>
-            ) : null}
-
-            {vsAi ? (
-              <Tabs.Panel value="advanced" pt="sm">
-                <Text size="xs" c="dimmed" mb="sm">
-                  {isEnglish ? 'Tune how the computer opponent plays.' : '調整電腦對手的下棋方式。'}
-                </Text>
-                <Text size="sm">{isEnglish ? 'Randomness' : '隨機性'}</Text>
-                <Text size="xs" c="dimmed">
-                  {isEnglish ? 'How unpredictable its moves are.' : '棋步的不可預測程度。'}
-                </Text>
-                <Slider
-                  min={0}
-                  max={3}
-                  step={0.1}
-                  label={(v) => v.toFixed(1)}
-                  value={createForm.values.randomness}
-                  onChange={(v) => createForm.setFieldValue('randomness', v)}
-                />
-                <Text size="sm" mt="md">
-                  {isEnglish ? 'Positional drive' : '進攻傾向'}
-                </Text>
-                <Text size="xs" c="dimmed">
-                  {isEnglish
-                    ? 'How much it favors advancing toward your side over holding position.'
-                    : '相較於固守陣地，電腦有多傾向向前推進。'}
-                </Text>
-                <Slider
-                  min={0}
-                  max={0.5}
-                  step={0.01}
-                  label={(v) => v.toFixed(2)}
-                  value={createForm.values.positionalDrive}
-                  onChange={(v) => createForm.setFieldValue('positionalDrive', v)}
-                />
-                <Text size="sm" mt="md">
-                  {isEnglish ? 'Caution' : '謹慎程度'}
-                </Text>
-                <Text size="xs" c="dimmed">
-                  {isEnglish
-                    ? 'How strongly it avoids exposing valuable pieces to risk.'
-                    : '電腦避免讓重要棋子暴露於風險中的程度。'}
-                </Text>
-                <Slider
-                  min={0}
-                  max={2}
-                  step={0.1}
-                  label={(v) => v.toFixed(1)}
-                  value={createForm.values.caution}
-                  onChange={(v) => createForm.setFieldValue('caution', v)}
-                />
-                <Text size="sm" mt="md">
-                  {isEnglish ? 'Aggression' : '侵略性'}
-                </Text>
-                <Text size="xs" c="dimmed">
-                  {isEnglish
-                    ? 'How much extra value it places on capturing pieces.'
-                    : '電腦對俘獲棋子賦予多少額外價值。'}
-                </Text>
-                <Slider
-                  min={0}
-                  max={3}
-                  step={0.1}
-                  label={(v) => v.toFixed(1)}
-                  value={createForm.values.aggression}
-                  onChange={(v) => createForm.setFieldValue('aggression', v)}
-                />
-              </Tabs.Panel>
-            ) : null}
-          </Tabs>
-          <br />
-          <Button variant="info" type="submit">
-            {isEnglish ? 'Create Match' : '建立對局'}
-          </Button>
-        </form>
-      </Container>
-    );
-  };
-
-  const JoinForm = ({ urlRoomId }) => {
-    const joinForm = useForm({
-      initialValues: {
-        // these keys must match the input keys for handlejoinSubmit
-        playerName,
-        roomId: urlRoomId,
-      },
-    });
-    return (
-      <Container style={cardStyle}>
-        <Title order={3}>{isEnglish ? 'Join a Game' : '加入遊戲'}</Title>
-        <form onSubmit={joinForm.onSubmit(handleJoinSubmit)}>
-          <TextInput
-            label={isEnglish ? 'Player name:' : '玩家名稱：'}
-            placeholder="Ex. Ian"
-            {...joinForm.getInputProps('playerName')}
-          />
-          <TextInput
-            label={isEnglish ? 'Join game:' : '加入代碼：'}
-            placeholder="Ex. 7K4X2P"
-            {...joinForm.getInputProps('roomId')}
-            disabled={!!urlRoomId}
-          />
-          <br />
-          <Button variant="info" type="submit">
-            {isEnglish ? 'Submit' : '送出'}
-          </Button>
-        </form>
-      </Container>
-    );
-  };
-
-  JoinForm.propTypes = {
-    urlRoomId: PropTypes.string,
-  };
-
-  const SpectateForm = ({ urlRoomId }) => {
-    const spectateForm = useForm({
-      initialValues: {
-        // these keys must match the input keys for handleSpectateSubmit
-        spectatorName,
-        roomId: urlRoomId,
-      },
-    });
-    return (
-      <Container style={cardStyle}>
-        <Title order={3}>{isEnglish ? 'Spectate a Game' : '觀戰遊戲'}</Title>
-        <form onSubmit={spectateForm.onSubmit(handleSpectateSubmit)}>
-          <TextInput
-            label={isEnglish ? 'Spectator name:' : '觀眾名稱：'}
-            placeholder="Ex. Ian"
-            {...spectateForm.getInputProps('spectatorName')}
-          />
-          <TextInput
-            label={isEnglish ? 'Spectate game:' : '觀戰代碼：'}
-            placeholder="Ex. 7K4X2P"
-            {...spectateForm.getInputProps('roomId')}
-            disabled={!!urlRoomId}
-          />
-          <br />
-          <Button variant="info" type="submit">
-            {isEnglish ? 'Submit' : '送出'}
-          </Button>
-        </form>
-      </Container>
-    );
-  };
-
   return (
     <>
       <Container style={viewStyle}>
@@ -427,9 +447,25 @@ function Menu({ joinedRoom = false, urlRoomId = '' }) {
               ))}
             </Container>
           ) : null}
-          {joinedRoom ? null : <CreateForm />}
-          <JoinForm urlRoomId={urlRoomId} />
-          <SpectateForm urlRoomId={urlRoomId} />
+          {joinedRoom ? null : (
+            <CreateForm
+              playerName={playerName}
+              isEnglish={isEnglish}
+              onSubmit={handleCreateSubmit}
+            />
+          )}
+          <JoinForm
+            playerName={playerName}
+            urlRoomId={urlRoomId}
+            isEnglish={isEnglish}
+            onSubmit={handleJoinSubmit}
+          />
+          <SpectateForm
+            spectatorName={spectatorName}
+            urlRoomId={urlRoomId}
+            isEnglish={isEnglish}
+            onSubmit={handleSpectateSubmit}
+          />
           <Container style={cardStyle}>
             <Title order={3}>For developers</Title>
             <Container style={cardContentStyle}>


### PR DESCRIPTION
## Summary
`CreateForm`, `JoinForm`, and `SpectateForm` were defined as inline function components inside `Menu`'s render body. That gives each a brand-new component identity on every `Menu` render - so toggling `isEnglish` (or any other `Menu`-level state change) caused React to unmount and remount all three, discarding whatever the user had already typed and reinitializing `useForm` from a stale `initialValues` snapshot. Reported as: typing a custom player name, then clicking the language toggle, silently reverted it to the random default.

Fix: hoists all three to module scope as ordinary named components with explicit props, so they have a stable identity across `Menu` re-renders (Mantine's `useForm` only reads `initialValues` on first mount, which is now the actual first mount, not a remount disguised as one).

## Test plan
- [x] `npm run build` succeeds, `eslint` clean (0 errors)
- [x] Live-verified via Playwright: typed a custom name into each of the three forms (Create/Join/Spectate), toggled the language back and forth, confirmed all three retain their typed values (previously all three reset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RHNokmAjWcnP6SJXn5ZKWi