### PR TITLE
fix(i18n): persist the language choice across page reloads

### DIFF
--- a/src/contexts/GameContext.jsx
+++ b/src/contexts/GameContext.jsx
@@ -25,6 +25,17 @@ if (import.meta.hot) {
 export const GameContext = createContext({});
 
 const sessionKey = (gameId) => `luzhanqi:session:${gameId}`;
+const LANGUAGE_KEY = 'luzhanqi:isEnglish';
+
+// defaults to Chinese (false) if nothing was ever saved, or the saved
+// value can't be parsed
+const loadIsEnglish = () => {
+  try {
+    return JSON.parse(window.localStorage.getItem(LANGUAGE_KEY)) === true;
+  } catch {
+    return false;
+  }
+};
 
 const saveSession = (gameId, name, token) => {
   if (!gameId || !token) return;
@@ -89,7 +100,7 @@ export const GameProvider = ({ children }) => {
     target: [],
   });
   const [successors, setSuccessors] = useState([]);
-  const [isEnglish, setIsEnglish] = useState(false);
+  const [isEnglish, setIsEnglish] = useState(loadIsEnglish);
   // rule-variant config (flyingBombs/landminesSurvive/captureTheFlag/...)
   // set by the host in the Lobby - needed locally so move highlighting and
   // combat-outcome prediction match how the server will actually resolve them
@@ -100,6 +111,10 @@ export const GameProvider = ({ children }) => {
   const isEnglishRef = useRef(isEnglish);
   useEffect(() => {
     isEnglishRef.current = isEnglish;
+    // persist across refreshes/new tabs - otherwise every reload silently
+    // fell back to the useState(false) default regardless of what the
+    // player had picked
+    window.localStorage.setItem(LANGUAGE_KEY, JSON.stringify(isEnglish));
   }, [isEnglish]);
 
   /**


### PR DESCRIPTION
## Summary
`isEnglish` was plain `useState(false)` with no persistence, so every page reload silently reset it to Chinese regardless of what the player had picked in the NavBar toggle.

Lazily initializes from `localStorage` (`luzhanqi:isEnglish`, defaulting to Chinese if unset or unparseable, matching the existing default) and writes through on every change, right alongside the existing `isEnglishRef` sync effect.

## Test plan
- [x] `npm run build` succeeds, `eslint` clean (0 errors)
- [x] Live-verified via Playwright: toggled to English, confirmed `localStorage` holds `"true"`, reloaded the page, confirmed the toggle button and page text are still in English
- [x] Also verified a brand-new browser context (no prior `localStorage`) still defaults to Chinese