### PR TITLE
chore(prettier): remove dead jsxBracketSameLine option

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -4,6 +4,5 @@
   "printWidth": 100,
   "singleQuote": true,
   "trailingComma": "es5",
-  "jsxBracketSameLine": true,
   "endOfLine": "auto"
 }


### PR DESCRIPTION
## Summary
`.prettierrc.json` set `jsxBracketSameLine: true`, deprecated in Prettier 2.4 in favor of `bracketSameLine`. Confirmed live that the Prettier version this repo actually runs (2.8.8 - same version the pre-commit hook and CI use) prints a deprecation warning for it and has **zero effect**: closing JSX brackets on their own line for a multi-line opening tag is the enforced style regardless of this setting.

No behavior change, except IDEs will no longer attempt no-op bracket changes.

## Test plan
- [x] `npx prettier --check src/` - clean (aside from one pre-existing, unrelated formatting nit in `pieceData.json`, left untouched)
- [x] `npm run build` succeeds, `eslint` clean