### PR TITLE
chore(jsconfig): remove baseUrl, deprecated and removed in TypeScript 7

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": "./",
     "paths": {
       "contexts/*": ["./src/contexts/*"],
       "components/*": ["./src/components/*"],


### PR DESCRIPTION
## Summary
`baseUrl` was deprecated in TypeScript 5.5.

## Test plan
- [x] `npm run build` succeeds (Vite's own alias resolution is unaffected either way)
- [x] Verified against a real, freshly-installed TypeScript 7.0: before the change, `tsc -p jsconfig.json` throws `TS5102` on `baseUrl`; after, it resolves cleanly with no errors, and an aliased import (`contexts/GameContext`) still resolves correctly