### PR TITLE
fix(app): keep the error boundary's fallback UI inside MantineProvider

### DIFF
--- a/src/components/UserModal/UserModal.jsx
+++ b/src/components/UserModal/UserModal.jsx
@@ -24,12 +24,19 @@ const UserModal = ({ showModal, setShowModal, isEnglish }) => {
         console.warn('User not found, creating it now');
         myUser = await createUser(user.uid);
       }
-      setUserData(myUser);
+      setUserData(myUser || {});
       setArchivedIds(new Set(myUser?.archivedGames || []));
       return myUser;
     };
 
     const fetchGames = async (fetchedUser) => {
+      // both the fetch and the create-on-miss fallback can fail (e.g. the
+      // backend rejecting the request entirely) - nothing to fetch games
+      // for in that case
+      if (!fetchedUser) {
+        console.warn('No user data available, skipping game history fetch');
+        return;
+      }
       console.info(`fetching ${fetchedUser.uid} games`);
       const myGames = await Promise.all(
         fetchedUser.games.map(async (gameId) => {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -31,24 +31,27 @@ axios.interceptors.request.use(async (config) => {
 
 createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <ErrorBoundary>
-      <BrowserRouter>
-        <FirebaseAuthProvider>
-          <MantineProvider
-            stylesTransform={emotionTransform}
-            theme={{
-              ...theme,
-              other,
-            }}
-          >
-            <MantineEmotionProvider>
+    <BrowserRouter>
+      <FirebaseAuthProvider>
+        <MantineProvider
+          stylesTransform={emotionTransform}
+          theme={{
+            ...theme,
+            other,
+          }}
+        >
+          <MantineEmotionProvider>
+            {/* inside MantineProvider so the fallback UI (which itself
+             * uses Mantine components) still has theme context to render
+             * against if something below throws */}
+            <ErrorBoundary>
               <GameProvider>
                 <App />
               </GameProvider>
-            </MantineEmotionProvider>
-          </MantineProvider>
-        </FirebaseAuthProvider>
-      </BrowserRouter>
-    </ErrorBoundary>
+            </ErrorBoundary>
+          </MantineEmotionProvider>
+        </MantineProvider>
+      </FirebaseAuthProvider>
+    </BrowserRouter>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- `index.jsx` had `ErrorBoundary` wrapping `MantineProvider` from the *outside*. Whenever anything below threw during render, the boundary's fallback (`<Flex>`, `<Title>`, `<Button>` from `@mantine/core`) replaced the whole subtree - including `MantineProvider` itself - so the fallback rendered with zero Mantine context, crashing with `Uncaught Error: @mantine/core: MantineProvider was not found in component tree` instead of showing "Something went wrong."
- This is very likely the actual mechanism behind #161's blank-page report: some other error trips the boundary, and the boundary's own fallback then crashes a second time in a way that produces this specific, confusing error message.
- Moved `ErrorBoundary` to be a child of `MantineProvider`/`MantineEmotionProvider` (still wraps `GameProvider`/`App`, so it catches the same errors) so its fallback always has theme context.
- Also hardened `UserModal.jsx`'s `fetchGames` against a still-`undefined` user after both `getUser` and the create-on-miss fallback fail (e.g. a backend that rejects every authenticated request) - this was one concrete, locally-reproducible way to trip the boundary (`fetching ${fetchedUser.uid}` throwing on `undefined.uid`).

## Test plan
- [x] Reproduced the original crash mechanism directly: temporarily made `App` throw on render, confirmed that *before* this fix, the boundary's fallback itself crashed with the Mantine error (blank page); *after* the fix, the fallback renders correctly ("Something went wrong" / Reload button, fully styled)
- [x] Verified a clean app boot with no console/page errors
- [x] `eslint` clean