### PR TITLE
fix(user-modal): restore table borders and clean up mobile/desktop layout

### DIFF
--- a/src/components/UserModal/UserModal.jsx
+++ b/src/components/UserModal/UserModal.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
-import { Button, Title, Text } from '@mantine/core';
+import { ActionIcon, Box, Button, Title, Text } from '@mantine/core';
+import { IconX } from '@tabler/icons-react';
 import Modal from 'react-modal';
 import PropTypes from 'prop-types';
 import { isEmpty } from 'lodash';
@@ -89,126 +90,171 @@ const UserModal = ({ showModal, setShowModal, isEnglish }) => {
           zIndex: 120,
         },
         content: {
-          width: '80%',
-          maxWidth: '600px',
-          height: '70%',
+          // override react-modal's default 40px top/left/right/bottom inset
+          // - margin:auto needs the full viewport to center within, since 2x
+          // 40px insets leave less room than minWidth on narrow phone
+          // screens, forcing the box off-center
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          width: 'auto',
+          minWidth: '320px',
+          maxWidth: 'min(600px, 90vw)',
+          maxHeight: '80vh',
           margin: 'auto',
           backgroundColor: '#ffffff',
+          padding: 0,
+          display: 'flex',
+          flexDirection: 'column',
         },
       }}
     >
+      {/* position:relative lives here, not on react-modal's own content box -
+       * that box relies on position:absolute + left/right + margin:auto
+       * (from react-modal's default styles) to stay centered, and overriding
+       * it to relative turns those left/right insets into an offset instead
+       * of a centering anchor, pushing the modal off-center */}
       <div
         style={{
+          position: 'relative',
           display: 'flex',
-          flexDirection: 'row',
-          justifyContent: 'flex-end',
+          flexDirection: 'column',
+          flex: 1,
+          minHeight: 0,
         }}
       >
-        <Button variant="subtle" color="red" onClick={() => setShowModal(false)}>
-          X
-        </Button>
-      </div>
-      <Title size={25}>
-        {isEnglish ? 'Hi, ' : '您好，'}
-        {user?.displayName || user?.phoneNumber || user?.email}
-      </Title>
-      <Text>
-        {isEnglish ? (
-          <>
-            You&apos;ve played{' '}
-            <Text span fw={700}>
-              {userData?.games?.length || 'no'}
-            </Text>{' '}
-            games
-          </>
-        ) : (
-          <>
-            您已經玩過{' '}
-            <Text span fw={700}>
-              {userData?.games?.length || 0}
-            </Text>{' '}
-            場遊戲
-          </>
-        )}
-      </Text>
+        <ActionIcon
+          variant="subtle"
+          color="gray"
+          radius="xl"
+          size="lg"
+          onClick={() => setShowModal(false)}
+          aria-label={isEnglish ? 'Close' : '關閉'}
+          sx={{ position: 'absolute', top: '0.5em', right: '0.5em', zIndex: 10 }}
+        >
+          <IconX size={20} />
+        </ActionIcon>
+        <Box sx={{ flex: 1, minHeight: 0, overflowY: 'auto', padding: '1.5em' }}>
+          <Title size={25} pr="2em">
+            {isEnglish ? 'Hi, ' : '您好，'}
+            {user?.displayName || user?.phoneNumber || user?.email}
+          </Title>
+          <Text>
+            {isEnglish ? (
+              <>
+                You&apos;ve played{' '}
+                <Text span fw={700}>
+                  {userData?.games?.length || 'no'}
+                </Text>{' '}
+                games
+              </>
+            ) : (
+              <>
+                您已經玩過{' '}
+                <Text span fw={700}>
+                  {userData?.games?.length || 0}
+                </Text>{' '}
+                場遊戲
+              </>
+            )}
+          </Text>
 
-      <Text>
-        {isEnglish ? 'Your rank is ' : '您的排名是 '}
-        {userData?.rank || (isEnglish ? '(no rank)' : '（無排名）')}
-      </Text>
-      {/* create a table with columns date, opponent, win/loss, detail */}
-      {userData?.games?.length > 0 && (
-        <Table>
-          <thead>
-            <tr>
-              <th>{isEnglish ? 'Date' : '日期'}</th>
-              <th>{isEnglish ? 'Opponent' : '對手'}</th>
-              <th>{isEnglish ? 'Result' : '結果'}</th>
-              <th>{isEnglish ? 'Actions' : '操作'}</th>
-            </tr>
-          </thead>
-          <tbody>
-            {gameData.map((myGame) => {
-              if (!myGame.players) {
-                console.warn(`Failure to fetch a game:`, myGame);
-                return;
-              }
-              const isIncomplete = !myGame.winnerId;
-              return (
-                <tr key={myGame._id}>
-                  <td>{new Date(myGame.createdAt).toLocaleDateString()}</td>
-                  {myGame.hostId && myGame.hostId === myGame.clientId ? (
-                    <td>{isEnglish ? 'Yourself' : '您自己'}</td>
-                  ) : (
-                    <td>{myGame.hostId === user?.uid ? myGame.players[1] : myGame.players[0]}</td>
-                  )}
-                  <td>
-                    {myGame.winnerId === user?.uid
-                      ? isEnglish
-                        ? 'Win'
-                        : '勝利'
-                      : (myGame.winnerId && (isEnglish ? 'Loss' : '失敗')) ??
-                        (isEnglish ? 'Incomplete' : '未完成')}
-                  </td>
-                  <td>
-                    {isIncomplete ? (
-                      <div style={{ display: 'flex', gap: '0.4em', alignItems: 'center' }}>
-                        {archivedIds.has(myGame._id) ? (
-                          <>
-                            <Text size="xs" c="dimmed">
-                              {isEnglish ? 'Archived' : '已封存'}
-                            </Text>
-                            <Button
-                              size="xs"
-                              variant="outline"
-                              onClick={() => handleUnarchive(myGame._id)}
-                            >
-                              {isEnglish ? 'Unarchive' : '取消封存'}
-                            </Button>
-                          </>
+          <Text>
+            {isEnglish ? 'Your rank is ' : '您的排名是 '}
+            {userData?.rank || (isEnglish ? '(no rank)' : '（無排名）')}
+          </Text>
+          {/* create a table with columns date, opponent, win/loss, detail */}
+          {userData?.games?.length > 0 && (
+            <Box sx={{ overflowX: 'auto' }}>
+              <Table
+                striped
+                highlightOnHover
+                withTableBorder
+                withColumnBorders
+                sx={{ whiteSpace: 'nowrap', width: 'auto' }}
+              >
+                <Table.Thead>
+                  <Table.Tr>
+                    <Table.Th>{isEnglish ? 'Date' : '日期'}</Table.Th>
+                    <Table.Th>{isEnglish ? 'Opponent' : '對手'}</Table.Th>
+                    <Table.Th>{isEnglish ? 'Result' : '結果'}</Table.Th>
+                    <Table.Th>{isEnglish ? 'Actions' : '操作'}</Table.Th>
+                  </Table.Tr>
+                </Table.Thead>
+                <Table.Tbody>
+                  {gameData.map((myGame) => {
+                    if (!myGame.players) {
+                      console.warn(`Failure to fetch a game:`, myGame);
+                      return;
+                    }
+                    const isIncomplete = !myGame.winnerId;
+                    return (
+                      <Table.Tr key={myGame._id}>
+                        <Table.Td>
+                          {new Date(myGame.createdAt).toLocaleDateString(undefined, {
+                            year: '2-digit',
+                            month: 'numeric',
+                            day: 'numeric',
+                          })}
+                        </Table.Td>
+                        {myGame.hostId && myGame.hostId === myGame.clientId ? (
+                          <Table.Td>{isEnglish ? 'Yourself' : '您自己'}</Table.Td>
                         ) : (
-                          <>
-                            <Button size="xs" onClick={() => handleRejoin(myGame._id)}>
-                              {isEnglish ? 'Rejoin' : '重新加入'}
-                            </Button>
-                            <Button
-                              size="xs"
-                              variant="outline"
-                              onClick={() => handleArchive(myGame._id)}
-                            >
-                              {isEnglish ? 'Archive' : '封存'}
-                            </Button>
-                          </>
+                          <Table.Td>
+                            {myGame.hostId === user?.uid ? myGame.players[1] : myGame.players[0]}
+                          </Table.Td>
                         )}
-                      </div>
-                    ) : null}
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </Table>
-      )}
+                        <Table.Td>
+                          {myGame.winnerId === user?.uid
+                            ? isEnglish
+                              ? 'Win'
+                              : '勝利'
+                            : (myGame.winnerId && (isEnglish ? 'Loss' : '失敗')) ??
+                              (isEnglish ? 'Incomplete' : '未完成')}
+                        </Table.Td>
+                        <Table.Td>
+                          {isIncomplete ? (
+                            <div style={{ display: 'flex', gap: '0.4em', alignItems: 'center' }}>
+                              {archivedIds.has(myGame._id) ? (
+                                <>
+                                  <Text size="xs" c="dimmed">
+                                    {isEnglish ? 'Archived' : '已封存'}
+                                  </Text>
+                                  <Button
+                                    size="xs"
+                                    variant="outline"
+                                    onClick={() => handleUnarchive(myGame._id)}
+                                  >
+                                    {isEnglish ? 'Unarchive' : '取消封存'}
+                                  </Button>
+                                </>
+                              ) : (
+                                <>
+                                  <Button size="xs" onClick={() => handleRejoin(myGame._id)}>
+                                    {isEnglish ? 'Rejoin' : '重新加入'}
+                                  </Button>
+                                  <Button
+                                    size="xs"
+                                    variant="outline"
+                                    onClick={() => handleArchive(myGame._id)}
+                                  >
+                                    {isEnglish ? 'Archive' : '封存'}
+                                  </Button>
+                                </>
+                              )}
+                            </div>
+                          ) : null}
+                        </Table.Td>
+                      </Table.Tr>
+                    );
+                  })}
+                </Table.Tbody>
+              </Table>
+            </Box>
+          )}
+        </Box>
+      </div>
     </Modal>
   );
 };


### PR DESCRIPTION
- Switch the game-history table to Mantine's compound Table components (Table.Thead/Tr/Th/Tbody/Td) with withTableBorder/withColumnBorders, matching the same fix already applied to GameOver's tables - raw <thead>/<tr>/<th> markup doesn't pick up Mantine's table styling.
- Keep cell text on one line (nowrap) and let the table size to its own content instead of stretching to fill the modal, so there's no more wasted space after the actions column.
- Wrap the table in a horizontally-scrollable container and let the modal's body scroll independently of a pinned close button, instead of squeezing/wrapping columns on narrow screens.
- Replace the plain bordered "X" text button with a round icon button that stays fixed in place while the body scrolls beneath it.
- Size the modal to its content (bounded by a min/max width) instead of a fixed 80%/70vh box, and override react-modal's default 40px inset so margin:auto has the full viewport to center within - the previous fixed inset (40px * 2) left less room than the modal's min-width on narrow phone screens, pushing it off-center.
- Format the history table's date with a 2-digit year.

<img width="2560" height="1800" alt="centereddesktop" src="https://github.com/user-attachments/assets/b2b35c2c-7c1d-421a-b77f-949d8086f21b" />
<img width="750" height="1400" alt="centeredmobile" src="https://github.com/user-attachments/assets/5cfe60d4-68cf-4e1f-90cf-567e5358cb74" />
