### PR TITLE
fix(deps): upgrade react-toastify to fix React 19 crash on any toast

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "react-phone-input-2": "^2.15.1",
         "react-router": "^6.4.3",
         "react-router-dom": "^6.4.3",
-        "react-toastify": "^9.1.1",
+        "react-toastify": "^11.1.0",
         "socket.io-client": "^4.5.4",
         "unique-names-generator": "^4.3.1"
       },
@@ -9568,25 +9568,16 @@
       }
     },
     "node_modules/react-toastify": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.1.3.tgz",
-      "integrity": "sha512-fPfb8ghtn/XMxw3LkxQBk3IyagNpF/LIKjOBflbexr2AWxAH1MJgvnESwEwBn9liLFXgTKWgBSdZpw9m4OTHTg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.1.0.tgz",
+      "integrity": "sha512-e9h23x3phN0wbFeB6yovmWp7lobzV4CaCH0LO8nVP6H7Y+3GbcLpIzMm9dJhcp1RXbpyfvjgpfXqO80QAmn7sg==",
       "license": "MIT",
       "dependencies": {
-        "clsx": "^1.1.1"
+        "clsx": "^2.1.1"
       },
       "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/react-toastify/node_modules/clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "react-phone-input-2": "^2.15.1",
     "react-router": "^6.4.3",
     "react-router-dom": "^6.4.3",
-    "react-toastify": "^9.1.1",
+    "react-toastify": "^11.1.0",
     "socket.io-client": "^4.5.4",
     "unique-names-generator": "^4.3.1"
   },


### PR DESCRIPTION
react-toastify@9.x's ToastContainer sets its defaults (including `transition`, the prop it uses directly as `React.createElement(transition, ...)` for the toast wrapper) via `.defaultProps` on a function component - a pattern React 19 no longer honors. With `transition` silently undefined, every toast call throws "Element type is invalid: undefined" (React error #130), which is caught by the top-level ErrorBoundary - this is the "blank page" / minified-130 crash reported on luzhanqi.netlify.app (#161), reproduced here via both a field-marshal-death toast and, to confirm it wasn't specific to that path, a completely unrelated form-validation toast.error() - both crashed identically pre-fix.

Upgrades to ^11.1.0, which lists React 19 as a supported peer dependency and no longer relies on defaultProps. Verified: lint clean, build succeeds, and re-triggering both toast paths against the built output no longer crashes and renders the toast correctly.
