### PR TITLE
docs: drop a comment reference to a removed per-tile tooltip

### DIFF
--- a/src/components/SelectablePosition.jsx
+++ b/src/components/SelectablePosition.jsx
@@ -70,8 +70,8 @@ const SelectablePosition = forwardRef(function SelectablePosition(
     isLastMove
   );
 
-  // report hover to the parent (drives the desktop PieceInfoPanel) instead
-  // of the old per-tile tooltip; only fires while there's a real piece here
+  // reports hover to the parent, which drives the desktop PieceInfoPanel;
+  // only fires while there's a real piece here
   useEffect(() => {
     if (hovered && piece && piece.name) {
       onHoverPiece?.(piece);


### PR DESCRIPTION
Comments should describe the current code's behavior. Removed comments that don't comply.
