### PR TITLE
feat(game-board): highlight the last move with a persistent arrow

### DIFF
--- a/src/components/GameBoard/LastMoveArrow.jsx
+++ b/src/components/GameBoard/LastMoveArrow.jsx
@@ -1,30 +1,97 @@
-import LineTo from 'react-lineto';
+import { useLayoutEffect, useState } from 'react';
 import useWindowSize from 'hooks/useWindowSize';
 import PropTypes from 'prop-types';
 
-// draws a line between the last move's origin and destination cells, on
-// top of the cell-tint highlight, so the move stays traceable even when it
-// happens too fast to notice both cells changing color independently
-export default function LastMoveArrow({ lastMove }) {
-  useWindowSize(); // rerender on window resize for the line to update
+const ARROW_COLOR = 'darkorchid';
+// stop the line short of the destination cell's exact center so the
+// arrowhead doesn't land on top of the piece's name there
+const TARGET_PULLBACK_PX = 16;
 
-  if (!lastMove) {
+// draws a line with an arrowhead between the last move's origin and
+// destination cells, on top of the cell-tint highlight, so the move stays
+// traceable even when it happens too fast to notice both cells changing
+// color independently. Renders as an SVG overlay sized to containerRef (a
+// position:relative ancestor also wrapping the board Grid), and measures
+// both cells relative to that same container, so the line lines up
+// correctly regardless of scroll position - no viewport/document
+// coordinate math or portal needed.
+export default function LastMoveArrow({ lastMove, containerRef }) {
+  const [line, setLine] = useState(null);
+  const [width] = useWindowSize();
+
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    if (!lastMove || !container) {
+      setLine(null);
+      return;
+    }
+    const { source, target } = lastMove;
+    const fromEl = document.getElementsByClassName(`${source[0]}-${source[1]}`)[0];
+    const toEl = document.getElementsByClassName(`${target[0]}-${target[1]}`)[0];
+    if (!fromEl || !toEl) {
+      setLine(null);
+      return;
+    }
+    const containerRect = container.getBoundingClientRect();
+    const fromRect = fromEl.getBoundingClientRect();
+    const toRect = toEl.getBoundingClientRect();
+    const x1 = fromRect.left + fromRect.width / 2 - containerRect.left;
+    const y1 = fromRect.top + fromRect.height / 2 - containerRect.top;
+    const x2Center = toRect.left + toRect.width / 2 - containerRect.left;
+    const y2Center = toRect.top + toRect.height / 2 - containerRect.top;
+    const dx = x2Center - x1;
+    const dy = y2Center - y1;
+    const dist = Math.sqrt(dx * dx + dy * dy);
+    const ratio = dist > TARGET_PULLBACK_PX ? (dist - TARGET_PULLBACK_PX) / dist : 0;
+    setLine({
+      x1,
+      y1,
+      x2: x1 + dx * ratio,
+      y2: y1 + dy * ratio,
+    });
+    // re-measure whenever the move changes or the layout might have
+    // shifted (window resize, via the width dependency)
+  }, [lastMove, containerRef, width]);
+
+  if (!line) {
     return null;
   }
 
-  const { source, target } = lastMove;
   return (
-    <LineTo
-      from={`${source[0]}-${source[1]}`}
-      to={`${target[0]}-${target[1]}`}
-      borderColor="darkorchid"
-      borderWidth={5}
-      borderStyle="solid"
-      toAnchor="center"
-      fromAnchor="center"
-      zIndex={200}
-      delay={0}
-    />
+    <svg
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: '100%',
+        pointerEvents: 'none',
+        zIndex: 200,
+        overflow: 'visible',
+      }}
+    >
+      <defs>
+        <marker
+          id="last-move-arrowhead"
+          markerWidth="4"
+          markerHeight="4"
+          refX="2.5"
+          refY="2"
+          orient="auto"
+        >
+          <path d="M0,0 L4,2 L0,4 Z" fill={ARROW_COLOR} />
+        </marker>
+      </defs>
+      <line
+        x1={line.x1}
+        y1={line.y1}
+        x2={line.x2}
+        y2={line.y2}
+        stroke={ARROW_COLOR}
+        strokeWidth={2.5}
+        markerEnd="url(#last-move-arrowhead)"
+      />
+    </svg>
   );
 }
 
@@ -33,4 +100,5 @@ LastMoveArrow.propTypes = {
     source: PropTypes.arrayOf(PropTypes.number),
     target: PropTypes.arrayOf(PropTypes.number),
   }),
+  containerRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }).isRequired,
 };

--- a/src/components/GameBoard/LastMoveArrow.jsx
+++ b/src/components/GameBoard/LastMoveArrow.jsx
@@ -1,0 +1,36 @@
+import LineTo from 'react-lineto';
+import useWindowSize from 'hooks/useWindowSize';
+import PropTypes from 'prop-types';
+
+// draws a line between the last move's origin and destination cells, on
+// top of the cell-tint highlight, so the move stays traceable even when it
+// happens too fast to notice both cells changing color independently
+export default function LastMoveArrow({ lastMove }) {
+  useWindowSize(); // rerender on window resize for the line to update
+
+  if (!lastMove) {
+    return null;
+  }
+
+  const { source, target } = lastMove;
+  return (
+    <LineTo
+      from={`${source[0]}-${source[1]}`}
+      to={`${target[0]}-${target[1]}`}
+      borderColor="darkorchid"
+      borderWidth={5}
+      borderStyle="solid"
+      toAnchor="center"
+      fromAnchor="center"
+      zIndex={200}
+      delay={0}
+    />
+  );
+}
+
+LastMoveArrow.propTypes = {
+  lastMove: PropTypes.shape({
+    source: PropTypes.arrayOf(PropTypes.number),
+    target: PropTypes.arrayOf(PropTypes.number),
+  }),
+};

--- a/src/components/GameBoard/index.jsx
+++ b/src/components/GameBoard/index.jsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from 'react';
-import { Grid, Container, Center, Button, Flex, Popover } from '@mantine/core';
+import { useState, useEffect, useRef } from 'react';
+import { Box, Grid, Container, Center, Button, Flex, Popover } from '@mantine/core';
 import { emptyBoard } from 'utils/core';
 import SelectablePosition from '../SelectablePosition';
 import PieceInfoPanel from '../PieceInfoPanel';
@@ -39,6 +39,7 @@ export default function GameBoard({
   const [hoveredPiece, setHoveredPiece] = useState(null);
   const [width] = useWindowSize();
   const showInfoPanel = width >= DESKTOP_PANEL_BREAKPOINT;
+  const gridContainerRef = useRef(null);
 
   const originSelected = !isEqual(origin, NO_SELECT);
   const destinationSelected = !isEqual(destination, NO_SELECT);
@@ -213,10 +214,12 @@ export default function GameBoard({
           )}
 
           <ConnectionLines />
-          <LastMoveArrow lastMove={lastMove} />
-          <Grid columns={20} gutter={6}>
-            {combined.map((cell) => cell)}
-          </Grid>
+          <Box ref={gridContainerRef} sx={{ position: 'relative' }}>
+            <LastMoveArrow lastMove={lastMove} containerRef={gridContainerRef} />
+            <Grid columns={20} gutter={6}>
+              {combined.map((cell) => cell)}
+            </Grid>
+          </Box>
         </Container>
         {showInfoPanel ? (
           <PieceInfoPanel

--- a/src/components/GameBoard/index.jsx
+++ b/src/components/GameBoard/index.jsx
@@ -8,6 +8,7 @@ import { isEqual } from 'lodash';
 import FrontLines from './FrontLines';
 import Mountain from './Mountain';
 import ConnectionLines from './ConnectionLines';
+import LastMoveArrow from './LastMoveArrow';
 import DeadPieces from './DeadPieces';
 import PropTypes from 'prop-types';
 import { getSuccessors } from 'utils';
@@ -212,6 +213,7 @@ export default function GameBoard({
           )}
 
           <ConnectionLines />
+          <LastMoveArrow lastMove={lastMove} />
           <Grid columns={20} gutter={6}>
             {combined.map((cell) => cell)}
           </Grid>

--- a/src/views/Game.jsx
+++ b/src/views/Game.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext, useEffect } from 'react';
 import { useParams } from 'react-router';
 import { GameContext } from 'contexts/GameContext';
 import { ToastContainer, toast } from 'react-toastify';
@@ -39,19 +39,6 @@ const Game = () => {
 
   const affiliation = playerList.indexOf(playerName);
 
-  /** Show the last move highlight immediately, then let it fade after a
-   * few seconds so it doesn't linger and clutter the board. */
-  const [lastMoveVisible, setLastMoveVisible] = useState(false);
-  useEffect(() => {
-    if (!lastMove) {
-      setLastMoveVisible(false);
-      return undefined;
-    }
-    setLastMoveVisible(true);
-    const timer = setTimeout(() => setLastMoveVisible(false), 2000);
-    return () => clearTimeout(timer);
-  }, [lastMove]);
-
   /** On mount (or a hard reload), silently try to reclaim a seat using a
    * locally-stored session - or, on a device with none but a logged-in
    * user, ask the server to match a verified uid against the game's
@@ -79,13 +66,12 @@ const Game = () => {
 
   // last move coordinates are always stored host-perspective; rotate for
   // display the same way the board itself is rotated for the guest
-  const displayLastMove =
-    lastMoveVisible && lastMove
-      ? {
-          source: host ? lastMove.source : rotateMove(lastMove.source),
-          target: host ? lastMove.target : rotateMove(lastMove.target),
-        }
-      : null;
+  const displayLastMove = lastMove
+    ? {
+        source: host ? lastMove.source : rotateMove(lastMove.source),
+        target: host ? lastMove.target : rotateMove(lastMove.target),
+      }
+    : null;
 
   const playerMakeMove = async (source, target, host) => {
     if (source.length && target.length) {


### PR DESCRIPTION
## Summary
- Closes #169 — in vs-AI mode, moves could resolve and un-highlight before the player noticed them.
- Draws a persistent arrow from the last move's origin to its destination cell, alongside the existing cell tint, instead of auto-hiding the highlight after a fixed 2s timer.
- Implemented as a self-contained SVG (`<line>` + `marker-end`) sized against a `position:relative` container via `getBoundingClientRect` differences, so it stays correctly positioned regardless of scroll position.
- The arrowhead stops short of the destination cell so it doesn't cover the piece's name there.

<img width="1800" height="1800" alt="image-1784394499997" src="https://github.com/user-attachments/assets/de798e05-b271-4648-a862-92362065498a" />
<img width="1800" height="1800" alt="image-1784394491914" src="https://github.com/user-attachments/assets/bdc899e0-b495-4647-8fb4-6eccf120b167" />


## Test plan
- [x] Verified via a scripted two-tab (host/guest) game session that the arrow renders correctly and stays visible until the next move, on both the host's and the rotated guest's view
- [x] `npm run build` and `eslint` pass