### PR TITLE
fix(deps): upgrade firebase to v12 to clear transitive protobufjs/grpc-js CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@mantine/hooks": "^7.17.8",
         "@tabler/icons-react": "^3.44.0",
         "axios": "^1.2.2",
-        "firebase": "^9.15.0",
+        "firebase": "^12.16.0",
         "framer-motion": "^12.42.2",
         "lodash": "^4.17.20",
         "lodash.isequal": "^4.5.0",
@@ -2259,16 +2259,36 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/@firebase/analytics": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.0.tgz",
-      "integrity": "sha512-Locv8gAqx0e+GX/0SI3dzmBY5e9kjVDtD+3zCFLJ0tH2hJwuCAiL+5WkHuxKj92rqQj/rvkBUCfA1ewlX2hehg==",
+    "node_modules/@firebase/ai": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.13.1.tgz",
+      "integrity": "sha512-RhT/VViTPBSplhQSuEp62HhLvfsV+LowMh8ZUo5MMRDzG7oFtSget4Kmg5oHP50hDVyWQuQj6to9iPFEZk08Tw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.4",
-        "@firebase/installations": "0.6.4",
-        "@firebase/logger": "0.4.0",
-        "@firebase/util": "1.9.3",
+        "@firebase/app-check-interop-types": "0.3.4",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics": {
+      "version": "0.10.22",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.22.tgz",
+      "integrity": "sha512-8BSaq/QRGU1+xyi8L2PTLTJU7MH9aMA72RQdIxrbhWFauOZY9OXo8f2YDN/972xA8d588tlnNVEQ2Mo69pT9Ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -2276,15 +2296,15 @@
       }
     },
     "node_modules/@firebase/analytics-compat": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.6.tgz",
-      "integrity": "sha512-4MqpVLFkGK7NJf/5wPEEP7ePBJatwYpyjgJ+wQHQGHfzaCDgntOnl9rL2vbVGGKCnRqWtZDIWhctB86UWXaX2Q==",
+      "version": "0.2.28",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.28.tgz",
+      "integrity": "sha512-lIAlqUUbBu93FJMlQfslryQtBwwzdzvp23ePC6FNgymXk6Ook5v4Uvc0vdutvoIeqmyA3LfP0ZeRFK8+11kOOQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/analytics": "0.10.0",
-        "@firebase/analytics-types": "0.8.0",
-        "@firebase/component": "0.6.4",
-        "@firebase/util": "1.9.3",
+        "@firebase/analytics": "0.10.22",
+        "@firebase/analytics-types": "0.8.4",
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -2292,130 +2312,155 @@
       }
     },
     "node_modules/@firebase/analytics-types": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.0.tgz",
-      "integrity": "sha512-iRP+QKI2+oz3UAh4nPEq14CsEjrjD6a5+fuypjScisAh9kXKFvdJOZJDwk7kikLvWVLGEs9+kIUS4LPQV7VZVw==",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.4.tgz",
+      "integrity": "sha512-zQ+XTgkwH6CY/eUSHJRP7e4LxM30RCxlCmob5sy2axs25GE3Ny0XdgpDscMTHHQIGqWkxPXad4w2Mw9sCgT8zQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/app": {
-      "version": "0.9.13",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.9.13.tgz",
-      "integrity": "sha512-GfiI1JxJ7ecluEmDjPzseRXk/PX31hS7+tjgBopL7XjB2hLUdR+0FTMXy2Q3/hXezypDvU6or7gVFizDESrkXw==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.15.1.tgz",
+      "integrity": "sha512-iD9+Z5HcPo0Uop5f72/VYMeXwKucBhW7iFrISkJFvQ+lSZikTNgTz0FgAtaaTkAG0pEZSnCymA2Fu49n0rcufQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.4",
-        "@firebase/logger": "0.4.0",
-        "@firebase/util": "1.9.3",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
         "idb": "7.1.1",
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@firebase/app-check": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.8.0.tgz",
-      "integrity": "sha512-dRDnhkcaC2FspMiRK/Vbp+PfsOAEP6ZElGm9iGFJ9fDqHoPs0HOPn7dwpJ51lCFi1+2/7n5pRPGhqF/F03I97g==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.12.0.tgz",
+      "integrity": "sha512-wMeT6HLWRAuW7Cp/5UjWBGKgjPNxWNOoNf4PRIv0weljoGMZVeqbUY7wNBWTI2/31cX1NlXx8gQruDLsUShB3Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.4",
-        "@firebase/logger": "0.4.0",
-        "@firebase/util": "1.9.3",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "@firebase/app": "0.x"
       }
     },
     "node_modules/@firebase/app-check-compat": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.3.7.tgz",
-      "integrity": "sha512-cW682AxsyP1G+Z0/P7pO/WT2CzYlNxoNe5QejVarW2o5ZxeWSSPAiVEwpEpQR/bUlUmdeWThYTMvBWaopdBsqw==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.4.5.tgz",
+      "integrity": "sha512-JI17mVcZs34zO6ZeSCrw4U2iohqy+n6GIzkbmsA+TbVjmvFLkUKt3bs5M+qRBteQm/0IWzqSHYFzEQLzDTQebg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app-check": "0.8.0",
-        "@firebase/app-check-types": "0.5.0",
-        "@firebase/component": "0.6.4",
-        "@firebase/logger": "0.4.0",
-        "@firebase/util": "1.9.3",
+        "@firebase/app-check": "0.12.0",
+        "@firebase/app-check-types": "0.5.4",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/app-check-interop-types": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.0.tgz",
-      "integrity": "sha512-xAxHPZPIgFXnI+vb4sbBjZcde7ZluzPPaSK7Lx3/nmuVk4TjZvnL8ONnkd4ERQKL8WePQySU+pRcWkh8rDf5Sg==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.4.tgz",
+      "integrity": "sha512-zz3i6e13B8BfWiLy8MABtTh8aGIACgKbf9UVnyHcWs+yQzJXgQcl8A46b0zfaiJHdQ+niF0ouAfcpuf+3LMPQg==",
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/app-check-types": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.0.tgz",
-      "integrity": "sha512-uwSUj32Mlubybw7tedRzR24RP8M8JUVR3NPiMk3/Z4bCmgEKTlQBwMXrehDAZ2wF+TsBq0SN1c6ema71U/JPyQ==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.4.tgz",
+      "integrity": "sha512-xV7JsIyzVr15aA7f3Pi0rB9gdBuVubs89FGA8VkRYA4g0l78poADgdfrScgf7NndSg9mm7cR7PJyY0+t22KaGw==",
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/app-compat": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.2.13.tgz",
-      "integrity": "sha512-j6ANZaWjeVy5zg6X7uiqh6lM6o3n3LD1+/SJFNs9V781xyryyZWXe+tmnWNWPkP086QfJoNkWN9pMQRqSG4vMg==",
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.15.tgz",
+      "integrity": "sha512-HaiSM9TwbGIR4b7F6+UncHWlqdH89eeY7VUskaOGOlI2PxHS5Z+6hHsYGvNLy0SHDE6zyXO+3QSA6a4aqQxsqA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app": "0.9.13",
-        "@firebase/component": "0.6.4",
-        "@firebase/logger": "0.4.0",
-        "@firebase/util": "1.9.3",
+        "@firebase/app": "0.15.1",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@firebase/app-types": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.0.tgz",
-      "integrity": "sha512-AeweANOIo0Mb8GiYm3xhTEBVCmPwTYAu9Hcd2qSkLuga/6+j9b1Jskl5bpiSQWy9eJ/j5pavxj6eYogmnuzm+Q==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@firebase/auth": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.23.2.tgz",
-      "integrity": "sha512-dM9iJ0R6tI1JczuGSxXmQbXAgtYie0K4WvKcuyuSTCu9V8eEDiz4tfa1sO3txsfvwg7nOY3AjoCyMYEdqZ8hdg==",
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.5.tgz",
+      "integrity": "sha512-YevqTjvo7Iujsa9Dwowmd6dSoElhzmD63ZSrq6bzjvQ6POjYgNjOFHLmNIgJs48eNO093NCERibuFnxbfOvU7A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.4",
-        "@firebase/logger": "0.4.0",
-        "@firebase/util": "1.9.3",
-        "node-fetch": "2.6.7",
+        "@firebase/logger": "0.5.1"
+      }
+    },
+    "node_modules/@firebase/auth": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.13.3.tgz",
+      "integrity": "sha512-bqiq4uubDN2YyQkdvSWPQeJyXAv2O76ImF41En9b6UhV5JuBVYDoHYrrrE3NzIuGkpFMKagfhMRP4Vz6t+yQSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
+      "engines": {
+        "node": ">=20.0.0"
+      },
       "peerDependencies": {
-        "@firebase/app": "0.x"
+        "@firebase/app": "0.x",
+        "@react-native-async-storage/async-storage": "^2.2.0 || ^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
       }
     },
     "node_modules/@firebase/auth-compat": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.4.2.tgz",
-      "integrity": "sha512-Q30e77DWXFmXEt5dg5JbqEDpjw9y3/PcP9LslDPR7fARmAOTIY9MM6HXzm9KC+dlrKH/+p6l8g9ifJiam9mc4A==",
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.8.tgz",
+      "integrity": "sha512-llcBREUC4iSNKZ6rvwud7Oz9Q7aAWU6KuQLa6pdu7Q+QAQsy4JLw6yFgxwtmzabsgznHmmcsX2UjHLLzqUxi3Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/auth": "0.23.2",
-        "@firebase/auth-types": "0.12.0",
-        "@firebase/component": "0.6.4",
-        "@firebase/util": "1.9.3",
-        "node-fetch": "2.6.7",
+        "@firebase/auth": "1.13.3",
+        "@firebase/auth-types": "0.13.1",
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/auth-interop-types": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.1.tgz",
-      "integrity": "sha512-VOaGzKp65MY6P5FI84TfYKBXEPi6LmOCSMMzys6o2BN2LOsqy7pCuZCup7NYnfbk5OkkQKzvIfHOzTm0UDpkyg==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.5.tgz",
+      "integrity": "sha512-1Li/YuBDBAXcKv7BzY4U28gontUmAaw53sYiqbaVOMCFb2lFKK/c3CGMUWqtwe7+TXrl3poWnTCL5umYBg85Eg==",
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/auth-types": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.12.0.tgz",
-      "integrity": "sha512-pPwaZt+SPOshK8xNoiQlK5XIrS97kFYc3Rc7xmy373QsOJ9MmqXxLaYssP5Kcds4wd2qK//amx/c+A8O2fVeZA==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.13.1.tgz",
+      "integrity": "sha512-0c1Mnid0uMDfGJHeUS4zfvBa4/CedJXotGy/n/NZJnBjwiJawt0ZYU+wH2VAVLiRCEfG2ncCkAX3yd1/2nrB7g==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@firebase/app-types": "0.x",
@@ -2423,95 +2468,124 @@
       }
     },
     "node_modules/@firebase/component": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.4.tgz",
-      "integrity": "sha512-rLMyrXuO9jcAUCaQXCMjCMUsWrba5fzHlNK24xz5j2W6A/SRmK8mZJ/hn7V0fViLbxC0lPMtrK1eYzk6Fg03jA==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.3.tgz",
+      "integrity": "sha512-wFofIaa2879ogD/WvkjYXJxRmfnL0scen6ORgaC3na1FNOR9ASIUANQdhqQcmWu/h77/pVHY7ch5flewa5Bcew==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/util": "1.9.3",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@firebase/database": {
-      "version": "0.14.4",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.14.4.tgz",
-      "integrity": "sha512-+Ea/IKGwh42jwdjCyzTmeZeLM3oy1h0mFPsTy6OqCWzcu/KFqRAr5Tt1HRCOBlNOdbh84JPZC47WLU18n2VbxQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/auth-interop-types": "0.2.1",
-        "@firebase/component": "0.6.4",
-        "@firebase/logger": "0.4.0",
-        "@firebase/util": "1.9.3",
-        "faye-websocket": "0.11.4",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@firebase/database-compat": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-0.3.4.tgz",
-      "integrity": "sha512-kuAW+l+sLMUKBThnvxvUZ+Q1ZrF/vFJ58iUY9kAcbX48U03nVzIF6Tmkf0p3WVQwMqiXguSgtOPIB6ZCeF+5Gg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/component": "0.6.4",
-        "@firebase/database": "0.14.4",
-        "@firebase/database-types": "0.10.4",
-        "@firebase/logger": "0.4.0",
-        "@firebase/util": "1.9.3",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@firebase/database-types": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.10.4.tgz",
-      "integrity": "sha512-dPySn0vJ/89ZeBac70T+2tWWPiJXWbmRygYv0smT5TfE3hDrQ09eKMF3Y+vMlTdrMWq7mUdYW5REWPSGH4kAZQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/app-types": "0.9.0",
-        "@firebase/util": "1.9.3"
-      }
-    },
-    "node_modules/@firebase/firestore": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-3.13.0.tgz",
-      "integrity": "sha512-NwcnU+madJXQ4fbLkGx1bWvL612IJN/qO6bZ6dlPmyf7QRyu5azUosijdAN675r+bOOJxMtP1Bv981bHBXAbUg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/component": "0.6.4",
-        "@firebase/logger": "0.4.0",
-        "@firebase/util": "1.9.3",
-        "@firebase/webchannel-wrapper": "0.10.1",
-        "@grpc/grpc-js": "~1.7.0",
-        "@grpc/proto-loader": "^0.6.13",
-        "node-fetch": "2.6.7",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=10.10.0"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/data-connect": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.7.1.tgz",
+      "integrity": "sha512-2LbUU8mmSA63HknxQMmWHjpzuNLBKflvVwQc2tpoVKg0biWleNEJX031ELks0vzFs+dDjOUkCJR72RP6mQHFOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth-interop-types": "0.2.5",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/database": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.3.tgz",
+      "integrity": "sha512-XwWCa+E4TvNGpGwXrycLRNfdogADwFcvuhyow6wDWma9W54roaQIhe+4PM0KiLsIftBdSCGI7OKCXrdSRHbIhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.4",
+        "@firebase/auth-interop-types": "0.2.5",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "faye-websocket": "0.11.4",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-compat": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.4.tgz",
+      "integrity": "sha512-3pK35F1MAgmqFJQlf2nhQl44vtAXQO1uaCaQOEUI9kCRtLFqi7N+QRKR7lFZPg+xIZIyubgxQaxY69YgfZRZWg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/database": "1.1.3",
+        "@firebase/database-types": "1.0.20",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-types": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.20.tgz",
+      "integrity": "sha512-kegbOk/w8iU64pr0q6k2ItyNGjnQBMHFhwS7ohdWI4W+pc0/zhhdGXTdFj6X1oxItRjPoYOsSQmERgBkn/ihxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-types": "0.9.5",
+        "@firebase/util": "1.15.1"
+      }
+    },
+    "node_modules/@firebase/firestore": {
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.16.0.tgz",
+      "integrity": "sha512-qdHMHMvMr0nRMuZyWNR/ArWa0YlPE3C4eAbmxTASJMYXAesKPL0Y54p70moggrNPzaK7MSIIq5RDJJyntQyIYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "@firebase/webchannel-wrapper": "1.0.6",
+        "@grpc/grpc-js": "~1.9.0",
+        "@grpc/proto-loader": "^0.7.8",
+        "re2js": "^0.4.2",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "@firebase/app": "0.x"
       }
     },
     "node_modules/@firebase/firestore-compat": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.3.12.tgz",
-      "integrity": "sha512-mazuNGAx5Kt9Nph0pm6ULJFp/+j7GSsx+Ncw1GrnKl+ft1CQ4q2LcUssXnjqkX2Ry0fNGqUzC1mfIUrk9bYtjQ==",
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.11.tgz",
+      "integrity": "sha512-W7o1WdwWq5aABK5Up2ncSvTQs/QGLR/fy7cVpFBNqhsXtxoMtflHf2xBIG6+aoptcuGAobddq4g2Sq27wqHaYw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.4",
-        "@firebase/firestore": "3.13.0",
-        "@firebase/firestore-types": "2.5.1",
-        "@firebase/util": "1.9.3",
+        "@firebase/component": "0.7.3",
+        "@firebase/firestore": "4.16.0",
+        "@firebase/firestore-types": "3.0.4",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/firestore-types": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-2.5.1.tgz",
-      "integrity": "sha512-xG0CA6EMfYo8YeUxC8FeDzf6W3FX1cLlcAGBYV6Cku12sZRI81oWcu61RSKM66K6kUENP+78Qm8mvroBcm1whw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.4.tgz",
+      "integrity": "sha512-jGn+JSS4X9zZsrfu7Yw66v5YRdOLD1oyQh4USR0xWl4CUqV/DA6bNIXRPpxH/cUl3iVTNiP6MN7g+EL42A4qfA==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@firebase/app-types": "0.x",
@@ -2519,54 +2593,59 @@
       }
     },
     "node_modules/@firebase/functions": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.10.0.tgz",
-      "integrity": "sha512-2U+fMNxTYhtwSpkkR6WbBcuNMOVaI7MaH3cZ6UAeNfj7AgEwHwMIFLPpC13YNZhno219F0lfxzTAA0N62ndWzA==",
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.13.5.tgz",
+      "integrity": "sha512-bWCx713f4kE/uFV7gdFOLBS7lDoiZj48MRkbAqe35gkXcCeWF4QjRNO07Jhmve7EJIoQOBczL29y2r8VRuN1kw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app-check-interop-types": "0.3.0",
-        "@firebase/auth-interop-types": "0.2.1",
-        "@firebase/component": "0.6.4",
-        "@firebase/messaging-interop-types": "0.2.0",
-        "@firebase/util": "1.9.3",
-        "node-fetch": "2.6.7",
+        "@firebase/app-check-interop-types": "0.3.4",
+        "@firebase/auth-interop-types": "0.2.5",
+        "@firebase/component": "0.7.3",
+        "@firebase/messaging-interop-types": "0.2.5",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "@firebase/app": "0.x"
       }
     },
     "node_modules/@firebase/functions-compat": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.3.5.tgz",
-      "integrity": "sha512-uD4jwgwVqdWf6uc3NRKF8cSZ0JwGqSlyhPgackyUPe+GAtnERpS4+Vr66g0b3Gge0ezG4iyHo/EXW/Hjx7QhHw==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.4.5.tgz",
+      "integrity": "sha512-10qlUXGY25G5/1g9UihqksPp2po+ZqSE7LEizsrdUP7vrTmkysXxGSZCDyojSEp6mQe/ecRDdDDI+z4XRdb4wQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.4",
-        "@firebase/functions": "0.10.0",
-        "@firebase/functions-types": "0.6.0",
-        "@firebase/util": "1.9.3",
+        "@firebase/component": "0.7.3",
+        "@firebase/functions": "0.13.5",
+        "@firebase/functions-types": "0.6.4",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/functions-types": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.0.tgz",
-      "integrity": "sha512-hfEw5VJtgWXIRf92ImLkgENqpL6IWpYaXVYiRkFY1jJ9+6tIhWM7IzzwbevwIIud/jaxKVdRzD7QBWfPmkwCYw==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.4.tgz",
+      "integrity": "sha512-zV6kgqtduR4rUAdC/ilS7kmb93XD7bEZoJDlVBZqlOw2uGGGCNBQBuleww2rr0Ulr3L9o2TDjumEt68/l1f9DQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/installations": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.4.tgz",
-      "integrity": "sha512-u5y88rtsp7NYkCHC3ElbFBrPtieUybZluXyzl7+4BsIz4sqb4vSAuwHEUgCgCeaQhvsnxDEU6icly8U9zsJigA==",
+      "version": "0.6.22",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.22.tgz",
+      "integrity": "sha512-ef6nn3GGQTdReCfotRMG77PJZu8CqEbiK5pEoBnM0gTu/Z9v0i/az2p3HABsa/1beQmmyh1OsOjf7P5+pgwdZw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.4",
-        "@firebase/util": "1.9.3",
-        "idb": "7.0.1",
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "idb": "7.1.1",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -2574,15 +2653,15 @@
       }
     },
     "node_modules/@firebase/installations-compat": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.4.tgz",
-      "integrity": "sha512-LI9dYjp0aT9Njkn9U4JRrDqQ6KXeAmFbRC0E7jI7+hxl5YmRWysq5qgQl22hcWpTk+cm3es66d/apoDU/A9n6Q==",
+      "version": "0.2.22",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.22.tgz",
+      "integrity": "sha512-C/zpAuTP5S9OgKSPvXRupw3hoY/JZSlA1wFjD/Sb7LIQE0FNbcMdO8Y4KXVEkjVzma/DDDDIAzxEXqKMAzc88w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.4",
-        "@firebase/installations": "0.6.4",
-        "@firebase/installations-types": "0.5.0",
-        "@firebase/util": "1.9.3",
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/installations-types": "0.5.4",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -2590,40 +2669,37 @@
       }
     },
     "node_modules/@firebase/installations-types": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.0.tgz",
-      "integrity": "sha512-9DP+RGfzoI2jH7gY4SlzqvZ+hr7gYzPODrbzVD82Y12kScZ6ZpRg/i3j6rleto8vTFC8n6Len4560FnV1w2IRg==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.4.tgz",
+      "integrity": "sha512-U2eFapdHwjb43Vx9o+Pmj4dFfvcHEK1IirEFLqMtWrTHvmdrS3gBpBD1kmJk/9HjsOtoHZxJ2Paoe79e+L1ZPg==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@firebase/app-types": "0.x"
       }
     },
-    "node_modules/@firebase/installations/node_modules/idb": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/idb/-/idb-7.0.1.tgz",
-      "integrity": "sha512-UUxlE7vGWK5RfB/fDwEGgRf84DY/ieqNha6msMV99UsEMQhJ1RwbCd8AYBj3QMgnE3VZnfQvm4oKVCJTYlqIgg==",
-      "license": "ISC"
-    },
     "node_modules/@firebase/logger": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.0.tgz",
-      "integrity": "sha512-eRKSeykumZ5+cJPdxxJRgAC3G5NknY2GwEbKfymdnXtnT0Ucm4pspfR6GT4MUQEDuJwRVbVcSx85kgJulMoFFA==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.1.tgz",
+      "integrity": "sha512-vZKLsqE1ABOy8OjQiE7cUTFn4gvaqlk88yp8N94Pk/sDpq61YqZGqmVFZTvOyflTwuYFcWirBdYGoJgbDaXKYQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@firebase/messaging": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.4.tgz",
-      "integrity": "sha512-6JLZct6zUaex4g7HI3QbzeUrg9xcnmDAPTWpkoMpd/GoSVWH98zDoWXMGrcvHeCAIsLpFMe4MPoZkJbrPhaASw==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.13.0.tgz",
+      "integrity": "sha512-GZoo0uGRvEbszo83xcgbjJp4FpkmBEr4l8Z4hi8gl+P1Spn/MTK3HapanMzSX4yUHuTEiF5hasWRxOaz+o5sxQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.4",
-        "@firebase/installations": "0.6.4",
-        "@firebase/messaging-interop-types": "0.2.0",
-        "@firebase/util": "1.9.3",
-        "idb": "7.0.1",
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/messaging-interop-types": "0.2.5",
+        "@firebase/util": "1.15.1",
+        "idb": "7.1.1",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -2631,14 +2707,14 @@
       }
     },
     "node_modules/@firebase/messaging-compat": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.4.tgz",
-      "integrity": "sha512-lyFjeUhIsPRYDPNIkYX1LcZMpoVbBWXX4rPl7c/rqc7G+EUea7IEtSt4MxTvh6fDfPuzLn7+FZADfscC+tNMfg==",
+      "version": "0.2.27",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.27.tgz",
+      "integrity": "sha512-JNOiu1PPgdHzEPEtoFiNxQuu0x9bm4bfETSQCpGfcTlgWkhlSK7uh7nlsjC10TQLUNgYetLmuutaYTh8aeYLVA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.4",
-        "@firebase/messaging": "0.12.4",
-        "@firebase/util": "1.9.3",
+        "@firebase/component": "0.7.3",
+        "@firebase/messaging": "0.13.0",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -2646,44 +2722,39 @@
       }
     },
     "node_modules/@firebase/messaging-interop-types": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.0.tgz",
-      "integrity": "sha512-ujA8dcRuVeBixGR9CtegfpU4YmZf3Lt7QYkcj693FFannwNuZgfAYaTmbJ40dtjB81SAu6tbFPL9YLNT15KmOQ==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.5.tgz",
+      "integrity": "sha512-tUEKnaAP2Y/MNIqgnriPpV6e5l13Vs/+p2yrd6NGlncPJT9O3a8muYZtdnWe+IJ4fgKLHJVC79n/asxk/N5Msw==",
       "license": "Apache-2.0"
     },
-    "node_modules/@firebase/messaging/node_modules/idb": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/idb/-/idb-7.0.1.tgz",
-      "integrity": "sha512-UUxlE7vGWK5RfB/fDwEGgRf84DY/ieqNha6msMV99UsEMQhJ1RwbCd8AYBj3QMgnE3VZnfQvm4oKVCJTYlqIgg==",
-      "license": "ISC"
-    },
     "node_modules/@firebase/performance": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.6.4.tgz",
-      "integrity": "sha512-HfTn/bd8mfy/61vEqaBelNiNnvAbUtME2S25A67Nb34zVuCSCRIX4SseXY6zBnOFj3oLisaEqhVcJmVPAej67g==",
+      "version": "0.7.12",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.12.tgz",
+      "integrity": "sha512-fe7nV8teUU3OBHlMUZ9Lw4gLhCW2k4m5Uc3pfWGV+fl8uwJQBGp9Q3lqsJ+HSrFu3Q2pJyLAgrClPGSKyDeYgQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.4",
-        "@firebase/installations": "0.6.4",
-        "@firebase/logger": "0.4.0",
-        "@firebase/util": "1.9.3",
-        "tslib": "^2.1.0"
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0",
+        "web-vitals": "^4.2.4"
       },
       "peerDependencies": {
         "@firebase/app": "0.x"
       }
     },
     "node_modules/@firebase/performance-compat": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.4.tgz",
-      "integrity": "sha512-nnHUb8uP9G8islzcld/k6Bg5RhX62VpbAb/Anj7IXs/hp32Eb2LqFPZK4sy3pKkBUO5wcrlRWQa6wKOxqlUqsg==",
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.25.tgz",
+      "integrity": "sha512-q6NjTXpIPoFuUmCmMN/maCdTgzT6aExs9xZo+PxfVLj6uLVGvpyAD6XWjmcrb7jChsFBYbq7E5dyNDF7Zhy9kA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.4",
-        "@firebase/logger": "0.4.0",
-        "@firebase/performance": "0.6.4",
-        "@firebase/performance-types": "0.2.0",
-        "@firebase/util": "1.9.3",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/performance": "0.7.12",
+        "@firebase/performance-types": "0.2.4",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -2691,21 +2762,21 @@
       }
     },
     "node_modules/@firebase/performance-types": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.0.tgz",
-      "integrity": "sha512-kYrbr8e/CYr1KLrLYZZt2noNnf+pRwDq2KK9Au9jHrBMnb0/C9X9yWSXmZkFt4UIdsQknBq8uBB7fsybZdOBTA==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.4.tgz",
+      "integrity": "sha512-kJSEk7b0uhpcPRyL4SQ/GPujLqk52XNKcXlnsKDbWGAb9vugcLvOU3u6zfEdwd+d8hWJb5S5ZizV1JFFI0nkKg==",
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/remote-config": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.4.4.tgz",
-      "integrity": "sha512-x1ioTHGX8ZwDSTOVp8PBLv2/wfwKzb4pxi0gFezS5GCJwbLlloUH4YYZHHS83IPxnua8b6l0IXUaWd0RgbWwzQ==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.9.0.tgz",
+      "integrity": "sha512-aNn6/eJhsSC+gXSToiXiYPv3ypLP9lFtzl+/q9kSOBPB7D6rae0Rt2uENZZLXGYbEgHYKQblOhijJAXGbbJjtQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.4",
-        "@firebase/installations": "0.6.4",
-        "@firebase/logger": "0.4.0",
-        "@firebase/util": "1.9.3",
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -2713,16 +2784,16 @@
       }
     },
     "node_modules/@firebase/remote-config-compat": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.4.tgz",
-      "integrity": "sha512-FKiki53jZirrDFkBHglB3C07j5wBpitAaj8kLME6g8Mx+aq7u9P7qfmuSRytiOItADhWUj7O1JIv7n9q87SuwA==",
+      "version": "0.2.27",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.27.tgz",
+      "integrity": "sha512-FYwYWwSbUdza/pRX4NpSBm/Pimntum3jEIBpnDn5Ey1jHNWgjxrE8Z5SB4mCHd5wGCoYd3koJzxARl/VWIEx0Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.4",
-        "@firebase/logger": "0.4.0",
-        "@firebase/remote-config": "0.4.4",
-        "@firebase/remote-config-types": "0.3.0",
-        "@firebase/util": "1.9.3",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/remote-config": "0.9.0",
+        "@firebase/remote-config-types": "0.5.1",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -2730,46 +2801,51 @@
       }
     },
     "node_modules/@firebase/remote-config-types": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.3.0.tgz",
-      "integrity": "sha512-RtEH4vdcbXZuZWRZbIRmQVBNsE7VDQpet2qFvq6vwKLBIQRQR5Kh58M4ok3A3US8Sr3rubYnaGqZSurCwI8uMA==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.5.1.tgz",
+      "integrity": "sha512-cX/1LT6KQwkXzck2eSzeKnuvXZCyr8qaPpDcikoJs7jmI+oBOXixpDLeDtWj1U6GNMkIoXrEDNoyT2Ypcyp5/A==",
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/storage": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.11.2.tgz",
-      "integrity": "sha512-CtvoFaBI4hGXlXbaCHf8humajkbXhs39Nbh6MbNxtwJiCqxPy9iH3D3CCfXAvP0QvAAwmJUTK3+z9a++Kc4nkA==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.14.3.tgz",
+      "integrity": "sha512-YX4/YL6P6/fufSSeGnVhjWddcIXbFq2cWIhMKFTZo1E/Rtcl2mJj/BYUQTwJfcE1Tl8un1FOya4L05jcSLN/Eg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.4",
-        "@firebase/util": "1.9.3",
-        "node-fetch": "2.6.7",
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "@firebase/app": "0.x"
       }
     },
     "node_modules/@firebase/storage-compat": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.3.2.tgz",
-      "integrity": "sha512-wvsXlLa9DVOMQJckbDNhXKKxRNNewyUhhbXev3t8kSgoCotd1v3MmqhKKz93ePhDnhHnDs7bYHy+Qa8dRY6BXw==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.4.3.tgz",
+      "integrity": "sha512-gruVqjtUGX8tEoeNbaWXZm0Zfcfcb7fvmDmBxV8yPAbWvExRnZYLO2+qw9idxNE7BvPXt5csyjSYHy//dAizxw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.4",
-        "@firebase/storage": "0.11.2",
-        "@firebase/storage-types": "0.8.0",
-        "@firebase/util": "1.9.3",
+        "@firebase/component": "0.7.3",
+        "@firebase/storage": "0.14.3",
+        "@firebase/storage-types": "0.8.4",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/storage-types": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.0.tgz",
-      "integrity": "sha512-isRHcGrTs9kITJC0AVehHfpraWFui39MPaU7Eo8QfWlqW7YPymBmRgjDrlOgFdURh6Cdeg07zmkLP5tzTKRSpg==",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.4.tgz",
+      "integrity": "sha512-BT7cwxJOx8SWwlQfrlC+bD/Sk3Cw+1odCi8UZNFNWTVZoPsBnA5W+mqtZzVnvsdJpXCFGSGQ7R7vOR6dtM/BRA==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@firebase/app-types": "0.x",
@@ -2777,18 +2853,22 @@
       }
     },
     "node_modules/@firebase/util": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.9.3.tgz",
-      "integrity": "sha512-DY02CRhOZwpzO36fHpuVysz6JZrscPiBXD0fXp6qSrL9oNOx5KWICKdR95C0lSITzxp0TZosVyHqzatE8JbcjA==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.15.1.tgz",
+      "integrity": "sha512-LUdM4Wg7YM9Pq/49nGYySJA0CSQEKnGffFzWV8+6gXN7mGxn+FL1IqvFbuZUtAQcfZgHYDwCE1wwlK7rB7gl2g==",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@firebase/webchannel-wrapper": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.10.1.tgz",
-      "integrity": "sha512-Dq5rYfEpdeel0bLVN+nfD1VWmzCkK+pJbSjIawGE+RY4+NIJqhbUDDQjvV0NUK84fMfwxvtFoCtEe70HfZjFcw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.6.tgz",
+      "integrity": "sha512-Vr/Mqu79dMwGRAyGbJ4uN4+BtXB3/mRTdzetD1daWNeG8QaWuzhhbG77GltO5c0yYmYls8i250iX73624GJd7Q==",
       "license": "Apache-2.0"
     },
     "node_modules/@floating-ui/core": {
@@ -2845,19 +2925,19 @@
       "license": "MIT"
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.7.3.tgz",
-      "integrity": "sha512-H9l79u4kJ2PVSxUNA08HMYAnUBLj9v6KjYQ7SQ71hOZcEXhShE/y5iQCesP8+6/Ik/7i2O0a10bPquIcYfufog==",
+      "version": "1.9.16",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.16.tgz",
+      "integrity": "sha512-wE4Ut/olIzfKqp631XrG+wbF0v1vWFN4YL9FyXC2LJiG33DsV7PLzURjrCvY/6je2ntdRkeLpPDluzSRGaVltQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/proto-loader": "^0.7.0",
+        "@grpc/proto-loader": "^0.7.8",
         "@types/node": ">=12.12.47"
       },
       "engines": {
         "node": "^8.13.0 || >=10.10.0"
       }
     },
-    "node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
+    "node_modules/@grpc/proto-loader": {
       "version": "0.7.15",
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
       "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
@@ -2867,95 +2947,6 @@
         "long": "^5.0.0",
         "protobufjs": "^7.2.5",
         "yargs": "^17.7.2"
-      },
-      "bin": {
-        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@grpc/grpc-js/node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@grpc/grpc-js/node_modules/long": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
-      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@grpc/grpc-js/node_modules/protobufjs": {
-      "version": "7.6.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
-      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.1",
-        "@protobufjs/fetch": "^1.1.1",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.1",
-        "@types/node": ">=13.7.0",
-        "long": "^5.3.2"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@grpc/grpc-js/node_modules/yargs": {
-      "version": "17.7.3",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
-      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@grpc/grpc-js/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@grpc/proto-loader": {
-      "version": "0.6.13",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.13.tgz",
-      "integrity": "sha512-FjxPYDRTn6Ec3V0arm1FtSpmP6V50wuph2yILpyvTKzjc76oDdoihXqM1DzOW5ubvCC8GivfCnNtfaRE8myJ7g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/long": "^4.0.1",
-        "lodash.camelcase": "^4.3.0",
-        "long": "^4.0.0",
-        "protobufjs": "^6.11.3",
-        "yargs": "^16.2.0"
       },
       "bin": {
         "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
@@ -3781,12 +3772,6 @@
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
@@ -4455,12 +4440,6 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/long": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -5226,14 +5205,17 @@
       }
     },
     "node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^6.0.1",
         "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/clsx": {
@@ -6650,37 +6632,39 @@
       }
     },
     "node_modules/firebase": {
-      "version": "9.23.0",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-9.23.0.tgz",
-      "integrity": "sha512-/4lUVY0lUvBDIaeY1q6dUYhS8Sd18Qb9CgWkPZICUo9IXpJNCEagfNZXBBFCkMTTN5L5gx2Hjr27y21a9NzUcA==",
+      "version": "12.16.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.16.0.tgz",
+      "integrity": "sha512-CNw6hFBdONkzF8UGLDx/RDRY9gVa5VmJNHd7qi4gdmA3ZuLkuOrhmWefB2l+FN+OxFpN77Itq7aO6zlTi780ag==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/analytics": "0.10.0",
-        "@firebase/analytics-compat": "0.2.6",
-        "@firebase/app": "0.9.13",
-        "@firebase/app-check": "0.8.0",
-        "@firebase/app-check-compat": "0.3.7",
-        "@firebase/app-compat": "0.2.13",
-        "@firebase/app-types": "0.9.0",
-        "@firebase/auth": "0.23.2",
-        "@firebase/auth-compat": "0.4.2",
-        "@firebase/database": "0.14.4",
-        "@firebase/database-compat": "0.3.4",
-        "@firebase/firestore": "3.13.0",
-        "@firebase/firestore-compat": "0.3.12",
-        "@firebase/functions": "0.10.0",
-        "@firebase/functions-compat": "0.3.5",
-        "@firebase/installations": "0.6.4",
-        "@firebase/installations-compat": "0.2.4",
-        "@firebase/messaging": "0.12.4",
-        "@firebase/messaging-compat": "0.2.4",
-        "@firebase/performance": "0.6.4",
-        "@firebase/performance-compat": "0.2.4",
-        "@firebase/remote-config": "0.4.4",
-        "@firebase/remote-config-compat": "0.2.4",
-        "@firebase/storage": "0.11.2",
-        "@firebase/storage-compat": "0.3.2",
-        "@firebase/util": "1.9.3"
+        "@firebase/ai": "2.13.1",
+        "@firebase/analytics": "0.10.22",
+        "@firebase/analytics-compat": "0.2.28",
+        "@firebase/app": "0.15.1",
+        "@firebase/app-check": "0.12.0",
+        "@firebase/app-check-compat": "0.4.5",
+        "@firebase/app-compat": "0.5.15",
+        "@firebase/app-types": "0.9.5",
+        "@firebase/auth": "1.13.3",
+        "@firebase/auth-compat": "0.6.8",
+        "@firebase/data-connect": "0.7.1",
+        "@firebase/database": "1.1.3",
+        "@firebase/database-compat": "2.1.4",
+        "@firebase/firestore": "4.16.0",
+        "@firebase/firestore-compat": "0.4.11",
+        "@firebase/functions": "0.13.5",
+        "@firebase/functions-compat": "0.4.5",
+        "@firebase/installations": "0.6.22",
+        "@firebase/installations-compat": "0.2.22",
+        "@firebase/messaging": "0.13.0",
+        "@firebase/messaging-compat": "0.2.27",
+        "@firebase/performance": "0.7.12",
+        "@firebase/performance-compat": "0.2.25",
+        "@firebase/remote-config": "0.9.0",
+        "@firebase/remote-config-compat": "0.2.27",
+        "@firebase/storage": "0.14.3",
+        "@firebase/storage-compat": "0.4.3",
+        "@firebase/util": "1.15.1"
       }
     },
     "node_modules/flat-cache": {
@@ -8377,9 +8361,9 @@
       }
     },
     "node_modules/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
     "node_modules/loose-envify": {
@@ -8572,26 +8556,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
       }
     },
     "node_modules/node-releases": {
@@ -9249,29 +9213,26 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "6.11.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.6.tgz",
-      "integrity": "sha512-k8BHqgPBOtrlougZZqF2uUk5Z7bN8f0wj+3e8M3hvtSv0NBAz4VBy5f6R5Nxq/l+i7mRFTgNZb2trxqTpHNY/A==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
+        "long": "^5.3.2"
       },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/proxy-from-env": {
@@ -9323,6 +9284,12 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/re2js": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/re2js/-/re2js-0.4.3.tgz",
+      "integrity": "sha512-EuNmh7jurhHEE8Ge/lBo9JuMLb3qf866Xjjfyovw3wPc7+hlqDkZq4LwhrCQMEI+ARWfrKrHozEndzlpNT0WDg==",
       "license": "MIT"
     },
     "node_modules/react": {
@@ -10750,12 +10717,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -11239,11 +11200,11 @@
         "loose-envify": "^1.0.0"
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
+    "node_modules/web-vitals": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
+      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "license": "Apache-2.0"
     },
     "node_modules/websocket-driver": {
       "version": "0.7.5",
@@ -11266,16 +11227,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -11850,30 +11801,30 @@
       }
     },
     "node_modules/yargs": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.2.tgz",
-      "integrity": "sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "license": "MIT",
       "dependencies": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
+        "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
+        "yargs-parser": "^21.1.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "license": "ISC",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@mantine/hooks": "^7.17.8",
     "@tabler/icons-react": "^3.44.0",
     "axios": "^1.2.2",
-    "firebase": "^9.15.0",
+    "firebase": "^12.16.0",
     "framer-motion": "^12.42.2",
     "lodash": "^4.17.20",
     "lodash.isequal": "^4.5.0",


### PR DESCRIPTION
## Summary
- `firebase@9.23.0`'s `@firebase/firestore` pulled in old, vulnerable `protobufjs`/`@grpc/grpc-js` versions via its Node gRPC transport — dead code for the browser bundle, but present in package-lock.json and flagged by Dependabot (13 alerts, including 1 critical and several high).
- Also directly resolves a firebase advisory (`_authTokenSyncURL` manipulation).
- Upgrades `firebase` from `^9.15.0` to `^12.16.0`. Only `firebase/auth` and `firebase/app` are used in this codebase (grep confirms no `firebase/firestore` usage), and both keep the same modular API surface across this range.

## Test plan
- [x] `npm run build` succeeds
- [x] Verified via a scripted headless-browser session: home page loads with no console errors/exceptions, and the login modal (email/password, phone, Google entry points — the components using `getAuth`/`GoogleAuthProvider`/`RecaptchaVerifier`/`signInWithPhoneNumber`) renders without crashing
- [x] `npm ls protobufjs @grpc/grpc-js` confirms only patched versions remain (protobufjs 6.11.6 and grpc-js 1.7.3 are gone)