### PR TITLE
fix(ci): restrict node.js.yml workflow's GITHUB_TOKEN to read-only

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
## Summary
- Closes the open CodeQL alert `actions/missing-workflow-permissions` on `.github/workflows/node.js.yml`.
- The workflow only checks out code, installs deps, builds, and runs tests - it never needs to write anything - but had no `permissions` block, so its `GITHUB_TOKEN` fell back to the repo/org default (potentially read-write).
- Adds a top-level `permissions: contents: read`.

## Test plan
- [x] YAML reviewed for correctness (no functional change to job steps)
- [ ] CI run on this PR itself confirms checkout/install/build/test still succeed under the restricted token