### PR TITLE
fix: post-move arrow floats above modals

### DIFF
--- a/src/components/AuthModal/AuthModal.jsx
+++ b/src/components/AuthModal/AuthModal.jsx
@@ -12,7 +12,7 @@ const AuthModal = ({ showModal, setShowModal, roomId, playerName, isEnglish }) =
     style={{
       overlay: {
         backgroundColor: '#00000080',
-        zIndex: 120,
+        zIndex: 300,
       },
       content: {
         width: '80%',

--- a/src/components/UserModal/UserModal.jsx
+++ b/src/components/UserModal/UserModal.jsx
@@ -88,7 +88,7 @@ const UserModal = ({ showModal, setShowModal, isEnglish }) => {
       style={{
         overlay: {
           backgroundColor: '#00000080',
-          zIndex: 120,
+          zIndex: 300,
         },
         content: {
           // override react-modal's default 40px top/left/right/bottom inset

--- a/src/components/WarnModal/WarnModal.jsx
+++ b/src/components/WarnModal/WarnModal.jsx
@@ -11,7 +11,7 @@ const WarnModal = ({ showModal, setShowModal, forfeit, isEnglish }) => (
     style={{
       overlay: {
         backgroundColor: '#00000080',
-        zIndex: 120,
+        zIndex: 300,
       },
       content: {
         width: '80%',


### PR DESCRIPTION
# Description

The purple arrow indicating a previously-made move should not float above modals.

<img width="558" height="724" alt="Screenshot 2026-07-19 at 20 26 34" src="https://github.com/user-attachments/assets/4c5ce7d6-768d-44e3-8b33-1df777fbbdc7" />


## Type of Change

- [ ] New feature
- [X] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [X] Unit/integration tests
- [ ] Documentation

## Screenshots

Please attach any design screenshots if UI update.
