### PR TITLE
docs: document the new CI/CD pipeline and add CONTRIBUTORS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,9 @@ socket.io-client for realtime gameplay, Firebase for optional auth, and
 
 There is no real test suite (`npm test` is a placeholder). Verify UI changes
 by actually running the app and driving the feature in a browser. CI
-(`.github/workflows/`) runs on Node 24.x.
+(`.github/workflows/ci.yml`) runs lint + build + `npm test` on Node 24.x on
+every PR/push to `main`, and is a required status check — see "Deployment"
+below for what happens after a PR merges.
 
 Needs a `.env`/`.env.local` with `VITE_API` pointing at a running
 luzhanqi-backend instance (see README.md). Vite env vars are baked in at
@@ -28,6 +30,24 @@ staged files.
 
 Use [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`,
 `fix:`, `refactor:`, `style:`, `docs:`, `chore:`, optionally with a scope).
+
+## Deployment
+
+`main` is the staging trigger; `production` is the prod trigger (the
+backend repo follows the same model). The pipeline:
+
+1. A PR into `main` must pass `ci.yml` before it can merge (branch
+   protection).
+2. Merging to `main` auto-deploys the `luzhanqi-staging` Netlify site.
+3. `.github/workflows/promote.yml`, triggered by that same push, polls
+   Netlify until that commit's staging deploy is `ready`, then smoke-tests
+   the staging URL (expects 200 and a `<div id="root">` in the body). Only
+   on success does it fast-forward `production` to match.
+4. Netlify auto-deploys the `luzhanqi` site (prod) from `production`.
+
+**Never push directly to `production`** — it only ever advances via step 3.
+Which branch each Netlify site tracks is configured in the Netlify
+dashboard (Site settings → Build & deploy), not in this repo.
 
 ## Layout
 
@@ -141,5 +161,6 @@ user.getIdToken() : null` (see `GameContext.jsx`'s `attemptRejoin`/
   reload during dev opens a new socket on top of the old one, which never
   gets closed (a no-op in production, where `import.meta.hot` doesn't
   exist).
-- Deploys to Netlify (staging + prod); `VITE_API` is set per deploy context
-  in Netlify's environment variable settings, not in this repo.
+- `VITE_API` is set per Netlify site in its environment variable settings,
+  not in this repo — see "Deployment" above for which branch feeds which
+  site.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,39 @@
+# Contributing to luzhanqi-web
+
+## Workflow
+
+1. Branch off `main` (`type/short-description`, e.g. `fix/last-move-arrow`,
+   `feat/rule-variant-toggle`, `chore/dep-bump`, `docs/...`).
+2. Open a PR into `main`. CI (`.github/workflows/ci.yml`: lint, build,
+   `npm test`) must pass — it's a required status check, so the merge
+   button stays disabled until it's green.
+3. Use [Conventional Commits](https://www.conventionalcommits.org/)
+   (`feat:`, `fix:`, `refactor:`, `style:`, `docs:`, `chore:`, optionally
+   with a scope) for commit messages and PR titles.
+4. Merge (this repo uses merge commits, not squash/rebase, so `git log`
+   keeps a per-PR merge commit).
+
+That's it from a contributor's side — everything after merge is automatic.
+See `AGENTS.md`'s "Deployment" section for what happens next (staging
+deploy → automated smoke test → promotion to production), and never push
+directly to the `production` branch, which only the promotion workflow
+should touch.
+
+## Local development
+
+- `npm install`, then `npm run start` — Vite dev server. See `README.md`
+  for the required `.env`/`.env.local`.
+- There's no real automated test suite yet (`npm test` is a placeholder) —
+  **verify UI changes by actually running the app and driving the feature
+  in a browser**, not just by reading the diff. Send/take a screenshot for
+  anything visual.
+- `npm run lint` / `npm run build` — same checks CI runs, useful to run
+  locally before pushing.
+
+## Getting oriented
+
+Start with `AGENTS.md` — it covers the codebase layout, the
+authentication model, the optimistic-move/board-orientation gameplay data
+flow, and known gotchas (stale closures in `GameContext`, Mantine v7's
+Emotion requirement, etc.) worth reading before touching game logic, auth,
+or the board UI.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,11 +13,24 @@
 4. Merge (this repo uses merge commits, not squash/rebase, so `git log`
    keeps a per-PR merge commit).
 
-That's it from a contributor's side — everything after merge is automatic.
-See `AGENTS.md`'s "Deployment" section for what happens next (staging
-deploy → automated smoke test → promotion to production), and never push
-directly to the `production` branch, which only the promotion workflow
-should touch.
+That's it from a contributor's side — everything after merge is automatic:
+
+```mermaid
+flowchart TD
+    A[PR opened against main] --> B{ci.yml\nlint + build + test}
+    B -- fail --> A
+    B -- pass, merged --> C[main updated]
+    C --> D[Netlify auto-deploys\nluzhanqi-staging]
+    D --> E{promote.yml\npoll staging deploy, then smoke test}
+    E -- fail --> F[Stops here\nproduction untouched]
+    E -- pass --> G[Fast-forward production\nto match main]
+    G --> H[Netlify auto-deploys\nluzhanqi prod site]
+```
+
+`main` is the staging trigger, `production` is the prod trigger — never
+push directly to `production`, since only `promote.yml`'s fast-forward
+should ever move it. If the smoke test fails, prod simply stays on its
+last good commit; nothing rolls out until it passes.
 
 ## Local development
 
@@ -32,8 +45,16 @@ should touch.
 
 ## Getting oriented
 
-Start with `AGENTS.md` — it covers the codebase layout, the
-authentication model, the optimistic-move/board-orientation gameplay data
-flow, and known gotchas (stale closures in `GameContext`, Mantine v7's
-Emotion requirement, etc.) worth reading before touching game logic, auth,
-or the board UI.
+- `src/views/` — top-level pages (`Game.jsx` is the main game screen,
+  `Menu.jsx` handles create/join/spectate).
+- `src/contexts/GameContext.jsx` — single source of truth for game state;
+  owns the socket connection and every socket event handler.
+- `src/contexts/FirebaseContext.jsx` — Firebase Auth state; never
+  fake/bypass this to get a logged-in user for testing.
+- `src/components/GameBoard/` — the live gameplay board; `src/components/BoardSetup/`
+  — the piece-placement (setup phase) board.
+- Every player-facing string is gated on the `isEnglish` flag (English or
+  Traditional Chinese) — new UI text needs both.
+- A rule-variant change must be mirrored in `utils/predictOutcome.js` /
+  `getSuccessors.js` here to match the backend's equivalent logic, or the
+  optimistic move preview and the real outcome will disagree.

--- a/README.md
+++ b/README.md
@@ -52,5 +52,5 @@ See the section about [deployment](https://facebook.github.io/create-react-app/d
 
 Merging a PR into `main` deploys to the staging site above, then a GitHub
 Actions workflow smoke-tests it and — if it passes — promotes it to
-production automatically. See `AGENTS.md`'s "Deployment" section for the
-full flow, and `CONTRIBUTORS.md` for the contribution workflow.
+production automatically. See `CONTRIBUTORS.md` for the full flow
+(including a diagram) and the contribution workflow.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Luzhanqi Web
+
+Production site: **https://luzhanqi.netlify.app**
 Staging site: **https://luzhanqi-staging.netlify.app**
 
 Ensure that you have ESLint and Prettier installed and enabled in VSCode.  
@@ -45,3 +47,10 @@ The build is minified and the filenames include the hashes.\
 Your app is ready to be deployed!
 
 See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
+
+## Deployment
+
+Merging a PR into `main` deploys to the staging site above, then a GitHub
+Actions workflow smoke-tests it and — if it passes — promotes it to
+production automatically. See `AGENTS.md`'s "Deployment" section for the
+full flow, and `CONTRIBUTORS.md` for the contribution workflow.


### PR DESCRIPTION
## Summary
- `AGENTS.md`: added a "Deployment" section describing the main=staging/production=prod promotion flow, and updated the stale CI/deploy notes.
- `README.md`: added the production site URL alongside staging.
- New `CONTRIBUTORS.md`: branch naming, PR/CI requirements, commit message convention, local dev pointers.