### PR TITLE
fix: react-lineto default-export interop broke under vite 8/Rolldown

### DIFF
--- a/src/components/BoardSetup/HalfBoard.jsx
+++ b/src/components/BoardSetup/HalfBoard.jsx
@@ -26,7 +26,7 @@ import { SortableContext, arrayMove } from '@dnd-kit/sortable';
 import SortablePiece from 'components/SortablePiece';
 import DraggablePiece from 'components/DraggablePiece';
 import GameTooltip from 'components/GameTooltip';
-import LineTo from 'react-lineto';
+import ReactLineTo from 'react-lineto';
 import Position from '../Position';
 import { setupPieces, pieces } from '../../models/Piece';
 import { exampleBoards } from '../../data/exampleBoards';
@@ -40,6 +40,12 @@ import {
 } from '../../utils';
 import useWindowSize from 'hooks/useWindowSize';
 import PropTypes from 'prop-types';
+
+// react-lineto is a CJS-only package (no "module"/"exports" field), and
+// different bundlers' dep-prebundling interop unwrap its default export to
+// different depths - this works regardless of which one the current
+// bundler does
+const LineTo = ReactLineTo.default || ReactLineTo;
 
 // returns a fresh 6x5 board every call - each row is a brand new array, so
 // callers can safely mutate individual cells without corrupting a shared

--- a/src/components/GameBoard/ConnectionLines.jsx
+++ b/src/components/GameBoard/ConnectionLines.jsx
@@ -1,6 +1,12 @@
-import LineTo from 'react-lineto';
+import ReactLineTo from 'react-lineto';
 import { isRailroad, boardConnections } from '../../utils/core';
 import useWindowSize from 'hooks/useWindowSize';
+
+// react-lineto is a CJS-only package (no "module"/"exports" field), and
+// different bundlers' dep-prebundling interop unwrap its default export to
+// different depths - this works regardless of which one the current
+// bundler does
+const LineTo = ReactLineTo.default || ReactLineTo;
 
 export default function ConnectionLines() {
   useWindowSize(); // rerender on window resize for lines to update


### PR DESCRIPTION
## Summary
**Production-breaking regression from the vite 5->8 bump (#181), currently live.** `react-lineto` is CJS-only (no `module`/`exports` field in its `package.json`), and Vite 8's Rolldown-based dep pre-bundler unwraps its default export one level shallower than Vite 5's esbuild-based one did - `import LineTo from 'react-lineto'` now resolves to `{default: LineTo, Line, SteppedLine, ...}` instead of the `LineTo` component itself, so React throws "Element type is invalid... but got: object" the moment either board tries to render its connection lines. This hits **every new game immediately** (board setup) and the live gameplay board - full ErrorBoundary crash.

Fixed by unwrapping defensively (`ReactLineTo.default || ReactLineTo`) in both call sites (`HalfBoard.jsx`, `ConnectionLines.jsx`), which works under either bundler's interop behavior.

## Test plan
- [x] Reproduced the crash live on `main` (confirmed via a console.error hook, since the ErrorBoundary swallows it visually) - `Element type is invalid... Check the render method of HalfBoardConnectionLines`
- [x] Confirmed the fix resolves it for both the setup board and the live gameplay board, in a real browser session
- [x] `npm run lint`, `npm run build`