### PR TITLE
chore: replace react-lineto with a custom SVG connection-line overlay

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-firebase-hooks": "^5.1.1",
-        "react-lineto": "^3.3.0",
         "react-modal": "^3.16.3",
         "react-phone-input-2": "^2.15.1",
         "react-router": "^6.4.3",
@@ -9492,27 +9491,6 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
       "license": "MIT"
-    },
-    "node_modules/react-lineto": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/react-lineto/-/react-lineto-3.3.0.tgz",
-      "integrity": "sha512-mDs9aX2ryM7lQ9G+XYZKmDmogzpR/2j1YYVQNDrcDbdgKloWOWcKaMkRX/9Ya4PHang4N1qxBbH3GUAIByDa6w==",
-      "license": "MIT",
-      "dependencies": {
-        "prop-types": "15.7.2",
-        "react": "17.0.2"
-      }
-    },
-    "node_modules/react-lineto/node_modules/prop-types": {
-      "version": "15.7.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.8.1"
-      }
     },
     "node_modules/react-modal": {
       "version": "3.16.3",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-firebase-hooks": "^5.1.1",
-    "react-lineto": "^3.3.0",
     "react-modal": "^3.16.3",
     "react-phone-input-2": "^2.15.1",
     "react-router": "^6.4.3",

--- a/src/components/BoardConnectionLines.jsx
+++ b/src/components/BoardConnectionLines.jsx
@@ -1,0 +1,84 @@
+import { useLayoutEffect, useState } from 'react';
+import useWindowSize from 'hooks/useWindowSize';
+import PropTypes from 'prop-types';
+
+// draws every board connection as an SVG line overlay sized to
+// containerRef (a position:relative ancestor also wrapping the board
+// Grid), measuring each pair of cells relative to that same container -
+// same approach as LastMoveArrow, generalized to many lines instead of
+// one. No line-drawing library needed: the board's connections are fully
+// known statically (see utils/core.js), so this is just two
+// getBoundingClientRect() calls and an SVG <line> per connection.
+export default function BoardConnectionLines({ connections, containerRef }) {
+  const [lines, setLines] = useState([]);
+  const [width] = useWindowSize();
+
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      setLines([]);
+      return;
+    }
+    const containerRect = container.getBoundingClientRect();
+    const measured = connections
+      .map(({ start, end, isRailroad }) => {
+        const fromEl = document.getElementsByClassName(`${start[0]}-${start[1]}`)[0];
+        const toEl = document.getElementsByClassName(`${end[0]}-${end[1]}`)[0];
+        if (!fromEl || !toEl) {
+          return null;
+        }
+        const fromRect = fromEl.getBoundingClientRect();
+        const toRect = toEl.getBoundingClientRect();
+        return {
+          key: `${start[0]}-${start[1]}-${end[0]}-${end[1]}`,
+          x1: fromRect.left + fromRect.width / 2 - containerRect.left,
+          y1: fromRect.top + fromRect.height / 2 - containerRect.top,
+          x2: toRect.left + toRect.width / 2 - containerRect.left,
+          y2: toRect.top + toRect.height / 2 - containerRect.top,
+          isRailroad,
+        };
+      })
+      .filter(Boolean);
+    setLines(measured);
+    // re-measure whenever the connection list changes or the layout might
+    // have shifted (window resize, via the width dependency)
+  }, [connections, containerRef, width]);
+
+  return (
+    <svg
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: '100%',
+        pointerEvents: 'none',
+        overflow: 'visible',
+      }}
+    >
+      {lines.map((line) => (
+        <line
+          key={line.key}
+          x1={line.x1}
+          y1={line.y1}
+          x2={line.x2}
+          y2={line.y2}
+          stroke={line.isRailroad ? 'gray' : 'black'}
+          strokeWidth={line.isRailroad ? 4 : 3}
+          strokeDasharray={line.isRailroad ? '8 6' : undefined}
+        />
+      ))}
+    </svg>
+  );
+}
+
+BoardConnectionLines.propTypes = {
+  connections: PropTypes.arrayOf(
+    PropTypes.shape({
+      start: PropTypes.arrayOf(PropTypes.number).isRequired,
+      end: PropTypes.arrayOf(PropTypes.number).isRequired,
+      isRailroad: PropTypes.bool,
+    })
+  ).isRequired,
+  containerRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }).isRequired,
+};

--- a/src/components/BoardSetup/HalfBoard.jsx
+++ b/src/components/BoardSetup/HalfBoard.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import {
   Container,
   Flex,
@@ -26,7 +26,7 @@ import { SortableContext, arrayMove } from '@dnd-kit/sortable';
 import SortablePiece from 'components/SortablePiece';
 import DraggablePiece from 'components/DraggablePiece';
 import GameTooltip from 'components/GameTooltip';
-import ReactLineTo from 'react-lineto';
+import BoardConnectionLines from '../BoardConnectionLines';
 import Position from '../Position';
 import { setupPieces, pieces } from '../../models/Piece';
 import { exampleBoards } from '../../data/exampleBoards';
@@ -38,14 +38,7 @@ import {
   isHalfBoardRailroad,
   isValidHalfBoardPlacement,
 } from '../../utils';
-import useWindowSize from 'hooks/useWindowSize';
 import PropTypes from 'prop-types';
-
-// react-lineto is a CJS-only package (no "module"/"exports" field), and
-// different bundlers' dep-prebundling interop unwrap its default export to
-// different depths - this works regardless of which one the current
-// bundler does
-const LineTo = ReactLineTo.default || ReactLineTo;
 
 // returns a fresh 6x5 board every call - each row is a brand new array, so
 // callers can safely mutate individual cells without corrupting a shared
@@ -56,6 +49,7 @@ const makeEmptyBoard = () => Array.from({ length: 6 }, () => [null, null, null, 
 
 export default function HalfBoard({ sendStartingBoard, playerList, playerName, isEnglish }) {
   const sensors = useSensors(useSensor(MouseSensor), useSensor(TouchSensor));
+  const gridContainerRef = useRef(null);
 
   // TODO: piece affiliation will be -1 if the players are not in game (playerList is [])
   const affiliatedPieces = setupPieces.map((piece) => ({
@@ -208,7 +202,6 @@ export default function HalfBoard({ sendStartingBoard, playerList, playerName, i
         },
       }}
     >
-      <HalfBoardConnectionLines />
       <DndContext
         autoScroll={false}
         sensors={sensors}
@@ -267,23 +260,26 @@ export default function HalfBoard({ sendStartingBoard, playerList, playerName, i
           <Box sx={{ position: 'sticky', top: 0, zIndex: 110 }}>
             <PieceSelector unplacedPieces={unplacedPieces} isEnglish={isEnglish} />
           </Box>
-          <Grid columns={20} gutter={6}>
-            {halfBoard.flatMap((row, r) =>
-              row.map((piece, c) => (
-                // eslint-disable-next-line react/no-array-index-key
-                <Grid.Col span={4} key={`${r}-${c}`}>
-                  <Position
-                    piece={piece}
-                    row={r}
-                    col={c}
-                    activeId={activeId}
-                    isHalfBoard={true}
-                    isEnglish={isEnglish}
-                  />
-                </Grid.Col>
-              ))
-            )}
-          </Grid>
+          <Box ref={gridContainerRef} sx={{ position: 'relative' }}>
+            <HalfBoardConnectionLines containerRef={gridContainerRef} />
+            <Grid columns={20} gutter={6}>
+              {halfBoard.flatMap((row, r) =>
+                row.map((piece, c) => (
+                  // eslint-disable-next-line react/no-array-index-key
+                  <Grid.Col span={4} key={`${r}-${c}`}>
+                    <Position
+                      piece={piece}
+                      row={r}
+                      col={c}
+                      activeId={activeId}
+                      isHalfBoard={true}
+                      isEnglish={isEnglish}
+                    />
+                  </Grid.Col>
+                ))
+              )}
+            </Grid>
+          </Box>
         </Stack>
         <DragOverlay>
           {activeId ? (
@@ -307,30 +303,18 @@ HalfBoard.propTypes = {
   isEnglish: PropTypes.bool.isRequired,
 };
 
-function HalfBoardConnectionLines() {
-  useWindowSize(); // rerender on window resize for lines to update
-  return (
-    <>
-      {halfBoardConnections.map(({ start, end }) => {
-        const isRailroadConnection = !!(
-          isHalfBoardRailroad(start[0], start[1]) && isHalfBoardRailroad(end[0], end[1])
-        );
-        return (
-          <LineTo
-            key={`${start[0]}-${start[1]}-${end[0]}-${end[1]}`}
-            from={`${start[0]}-${start[1]}`}
-            to={`${end[0]}-${end[1]}`}
-            borderColor={isRailroadConnection ? 'gray' : 'black'}
-            borderWidth={isRailroadConnection ? 4 : 3}
-            borderStyle={isRailroadConnection ? 'dashed' : 'solid'}
-            toAnchor="center"
-            delay={0}
-          />
-        );
-      })}
-    </>
-  );
+function HalfBoardConnectionLines({ containerRef }) {
+  const connections = halfBoardConnections.map(({ start, end }) => ({
+    start,
+    end,
+    isRailroad: !!(isHalfBoardRailroad(start[0], start[1]) && isHalfBoardRailroad(end[0], end[1])),
+  }));
+  return <BoardConnectionLines connections={connections} containerRef={containerRef} />;
 }
+
+HalfBoardConnectionLines.propTypes = {
+  containerRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }).isRequired,
+};
 
 function PieceSelector({ unplacedPieces, isEnglish }) {
   const { setNodeRef } = useDroppable({

--- a/src/components/GameBoard/ConnectionLines.jsx
+++ b/src/components/GameBoard/ConnectionLines.jsx
@@ -1,34 +1,16 @@
-import ReactLineTo from 'react-lineto';
 import { isRailroad, boardConnections } from '../../utils/core';
-import useWindowSize from 'hooks/useWindowSize';
+import BoardConnectionLines from '../BoardConnectionLines';
+import PropTypes from 'prop-types';
 
-// react-lineto is a CJS-only package (no "module"/"exports" field), and
-// different bundlers' dep-prebundling interop unwrap its default export to
-// different depths - this works regardless of which one the current
-// bundler does
-const LineTo = ReactLineTo.default || ReactLineTo;
-
-export default function ConnectionLines() {
-  useWindowSize(); // rerender on window resize for lines to update
-  return (
-    <>
-      {boardConnections.map(({ start, end }) => {
-        const isRailroadConnection = !!(
-          isRailroad(start[0], start[1]) && isRailroad(end[0], end[1])
-        );
-        return (
-          <LineTo
-            key={`${start[0]}-${start[1]}-${end[0]}-${end[1]}`}
-            from={`${start[0]}-${start[1]}`}
-            to={`${end[0]}-${end[1]}`}
-            borderColor={isRailroadConnection ? 'gray' : 'black'}
-            borderWidth={isRailroadConnection ? 4 : 3}
-            borderStyle={isRailroadConnection ? 'dashed' : 'solid'}
-            toAnchor="center"
-            delay={0}
-          />
-        );
-      })}
-    </>
-  );
+export default function ConnectionLines({ containerRef }) {
+  const connections = boardConnections.map(({ start, end }) => ({
+    start,
+    end,
+    isRailroad: !!(isRailroad(start[0], start[1]) && isRailroad(end[0], end[1])),
+  }));
+  return <BoardConnectionLines connections={connections} containerRef={containerRef} />;
 }
+
+ConnectionLines.propTypes = {
+  containerRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }).isRequired,
+};

--- a/src/components/GameBoard/index.jsx
+++ b/src/components/GameBoard/index.jsx
@@ -213,8 +213,8 @@ export default function GameBoard({
             </Center>
           )}
 
-          <ConnectionLines />
           <Box ref={gridContainerRef} sx={{ position: 'relative' }}>
+            <ConnectionLines containerRef={gridContainerRef} />
             <LastMoveArrow lastMove={lastMove} containerRef={gridContainerRef} />
             <Grid columns={20} gutter={6}>
               {combined.map((cell) => cell)}


### PR DESCRIPTION
## Summary
This is the second half of what became PR #183 - the PR got merged after just the animation-removal commit, before this commit (already pushed to that branch and CI-passing) made it in, so it never actually reached `main`. Re-opening it here as its own PR against current `main`.

`react-lineto` is unmaintained (last real update years ago), CJS-only, and its default-export interop is exactly what broke under vite 8/Rolldown (fixed defensively in #182). The board's connections are fully known statically (`utils/core.js`'s `boardConnections`/`halfBoardConnections` + `isRailroad`/`isHalfBoardRailroad`), so there was never any real need for a general-purpose line-drawing library here.

New `BoardConnectionLines` component (shared by both the live board's `ConnectionLines` and setup's `HalfBoardConnectionLines`, which previously duplicated the same rendering logic) measures each connection's two cells via `getBoundingClientRect()` relative to a container ref and draws plain SVG `<line>` elements - the same approach `LastMoveArrow` already used for a single line, generalized to many. Removes the `react-lineto` dependency and its defensive-unwrap workaround entirely.

## Test plan
- [x] `npm run lint`, `npm run build`
- [x] Verified live in an earlier session: both the setup board and the live gameplay board render all connections (dashed railroad, solid road, camp diagonals) identically to before, no console errors
- [x] Re-verified lint/build clean against current `main` tip