### PR TITLE
chore: add explicit least-privilege permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint-build-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -9,6 +9,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   STAGING_SITE_ID: df1fd67b-41bd-429a-a6fd-7be5c05c3812
   STAGING_URL: https://luzhanqi-staging.netlify.app


### PR DESCRIPTION
## Summary
CodeQL flagged both `ci.yml` and `promote.yml` (medium severity, `actions/missing-workflow-permissions`): neither declared an explicit `permissions:` block, so both fell back to the repo's default `GITHUB_TOKEN` scope instead of least-privilege.

Added a workflow-level `permissions: contents: read` default to both. `promote.yml`'s `promote` job already scopes `contents: write` at the job level for the one step that actually needs to push (the production fast-forward) - that override still takes precedence.

## Test plan
- [x] YAML parses cleanly
- [x] `npm run lint`