### PR TITLE
fix: gate move-sending on connection state and in-flight moves

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "extends": [
     "plugin:react/recommended",
     "plugin:jsx-a11y/recommended",

--- a/src/contexts/GameContext.jsx
+++ b/src/contexts/GameContext.jsx
@@ -150,6 +150,12 @@ export const GameProvider = ({ children }) => {
 
   /** whether a silent rejoin attempt is in flight for the current game ID */
   const [rejoining, setRejoining] = useState(false);
+  /** whether this socket currently has a live connection to the server -
+   * false between a drop and either a successful reconnect or the user
+   * giving up. See Game.jsx's isTurn gating: a move sent while this is
+   * false either never reaches the server or races a reconnect, so the
+   * board must not be clickable until it's true again. */
+  const [connected, setConnected] = useState(socket.connected);
   /** name of the opponent whose socket most recently disconnected, or null */
   const [disconnectedPlayer, setDisconnectedPlayer] = useState(null);
   /** in-progress games tied to the logged-in user's account that are worth
@@ -219,6 +225,7 @@ export const GameProvider = ({ children }) => {
     gameConfig: { gameConfig, setGameConfig },
     errors: { errors, setErrors },
     rejoining: { rejoining, setRejoining },
+    connected: { connected },
     disconnectedPlayer: { disconnectedPlayer, setDisconnectedPlayer },
     activeGames: { activeGames, setActiveGames },
     attemptRejoin,
@@ -238,6 +245,7 @@ export const GameProvider = ({ children }) => {
     socket.on('connect', () => {
       console.info(`SocketID: ${socket.id}`);
       console.info(`Connected: ${socket.connected}`);
+      setConnected(true);
       // the underlying transport can reconnect under a new socket.id after
       // a network drop or server restart without the page ever reloading -
       // React state (joinedGame, playerList, ...) survives that untouched,
@@ -251,6 +259,14 @@ export const GameProvider = ({ children }) => {
       if (roomId) {
         attemptRejoin(roomId);
       }
+    });
+
+    /** Transport dropped - until this fires false, we don't know whether a
+     * move already sent actually reached the server, so Game.jsx must not
+     * let another one be sent (see issue #109). Cleared back to true by
+     * 'connect' above, which also silently reclaims the seat. */
+    socket.on('disconnect', () => {
+      setConnected(false);
     });
 
     /** Server has created a new game, only host receives this message */

--- a/src/views/Game.jsx
+++ b/src/views/Game.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { useParams } from 'react-router';
 import { GameContext } from 'contexts/GameContext';
 import { ToastContainer, toast } from 'react-toastify';
@@ -34,10 +34,21 @@ const Game = () => {
     joinedGame: { joinedGame },
     rejoining: { rejoining },
     disconnectedPlayer: { disconnectedPlayer },
+    connected: { connected },
     attemptRejoin,
   } = useContext(GameContext);
 
   const affiliation = playerList.indexOf(playerName);
+
+  /** true from the moment a move is sent until the server's response (a
+   * turn change) or a rejection (an error) resolves it - blocks a second
+   * move from being sent in the meantime, including across a disconnect,
+   * where the fate of the first move isn't known until reconnection
+   * resyncs state (see issue #109). */
+  const [moveInFlight, setMoveInFlight] = useState(false);
+  useEffect(() => {
+    setMoveInFlight(false);
+  }, [clientTurn]);
 
   /** On mount (or a hard reload), silently try to reclaim a seat using a
    * locally-stored session - or, on a device with none but a logged-in
@@ -52,6 +63,12 @@ const Game = () => {
 
   /** Clear errors after 1 second each */
   useEffect(() => {
+    if (errors.length) {
+      // a rejected move is exactly the kind of error this list carries
+      // during gameplay - unblock sending rather than leaving the player
+      // stuck until some unrelated event happens to flip clientTurn
+      setMoveInFlight(false);
+    }
     errors.forEach((error) => {
       toast.error(error, {
         toastId: `${Date.now()}`,
@@ -85,6 +102,7 @@ const Game = () => {
       // corrects any guess this couldn't make (an attack on a fogged piece)
       setMyBoard((board) => applyMoveOptimistically(board, moveSource, moveTarget, gameConfig));
       setLastMove({ source: moveSource, target: moveTarget });
+      setMoveInFlight(true);
 
       socket.emit('playerMakeMove', {
         playerName,
@@ -221,7 +239,11 @@ const Game = () => {
           gamePhase === 2 || gamePhase === 3 ? (
             <GameBoard
               host={host}
-              isTurn={(host && clientTurn % 2 === 0) || (!host && clientTurn % 2 === 1)}
+              isTurn={
+                ((host && clientTurn % 2 === 0) || (!host && clientTurn % 2 === 1)) &&
+                connected &&
+                !moveInFlight
+              }
               board={host ? myBoard : transformBoard(myBoard)}
               deadPieces={myDeadPieces}
               sendMove={playerMakeMove}


### PR DESCRIPTION
## Summary
Fixes chinese-board-games/luzhanqi-backend#109. There was no client-side gate on repeat sends at all: `isTurn` (`Game.jsx`) only tracked whose turn it was, and `clientTurn` only ever updates from server events, so after clicking Send the board stayed fully interactive - a player could queue up several moves before the first one's result (or a disconnect) was known. The backend already rejects an out-of-turn move on reconnection, but the client let you try anyway.

Adds two gates, both required for `isTurn` to be true:
- **`moveInFlight`** (`Game.jsx`): set the instant a move is emitted, cleared when `clientTurn` actually changes (the move was acknowledged) or an error arrives (the move was rejected) - whichever resolves first.
- **`connected`** (`GameContext.jsx`): tracks the socket's live connection via new `connect`/`disconnect` handlers (only `connect` existed before). A move sent while disconnected either never reaches the server or races the eventual reconnect, so the board must stay non-interactive for the whole outage, not just up to the point a move was sent.

Also adds `"root": true` to `.eslintrc` - unrelated to the bug itself, but without it ESLint can't uniquely resolve plugins when this repo is checked out as a git worktree nested under another checkout of the same repo (as this fix was developed in). Harmless, standard practice otherwise.

## Test plan
- [x] `npm run lint`, `npm run build`
- [x] Verified live against a real backend (docker compose): made a normal move, then stopped the backend container mid-game and confirmed clicks on other pieces were silently ignored (the already-selected piece stayed selected, no new selection took over) for the entire outage, then restarted the backend and confirmed the socket reconnected (fresh socket.io handshake in network logs) and interactivity resumed (clicking the selected piece again correctly deselected it)