### PR TITLE
fix: color move arrows by affiliation

### DIFF
--- a/src/components/GameBoard/LastMoveArrow.jsx
+++ b/src/components/GameBoard/LastMoveArrow.jsx
@@ -2,7 +2,9 @@ import { useLayoutEffect, useState } from 'react';
 import useWindowSize from 'hooks/useWindowSize';
 import PropTypes from 'prop-types';
 
-const ARROW_COLOR = 'darkorchid';
+// blue for the viewing player's own moves, red for the opponent's (or the AI's)
+const FRIENDLY_COLOR = 'dodgerblue';
+const ENEMY_COLOR = 'crimson';
 // stop the line short of the destination cell's exact center so the
 // arrowhead doesn't land on top of the piece's name there
 const TARGET_PULLBACK_PX = 16;
@@ -15,7 +17,7 @@ const TARGET_PULLBACK_PX = 16;
 // both cells relative to that same container, so the line lines up
 // correctly regardless of scroll position - no viewport/document
 // coordinate math or portal needed.
-export default function LastMoveArrow({ lastMove, containerRef }) {
+export default function LastMoveArrow({ lastMove, containerRef, viewerAffiliation }) {
   const [line, setLine] = useState(null);
   const [width] = useWindowSize();
 
@@ -57,6 +59,8 @@ export default function LastMoveArrow({ lastMove, containerRef }) {
     return null;
   }
 
+  const color = lastMove.affiliation === viewerAffiliation ? FRIENDLY_COLOR : ENEMY_COLOR;
+
   return (
     <svg
       style={{
@@ -79,7 +83,7 @@ export default function LastMoveArrow({ lastMove, containerRef }) {
           refY="2"
           orient="auto"
         >
-          <path d="M0,0 L4,2 L0,4 Z" fill={ARROW_COLOR} />
+          <path d="M0,0 L4,2 L0,4 Z" fill={color} />
         </marker>
       </defs>
       <line
@@ -87,7 +91,7 @@ export default function LastMoveArrow({ lastMove, containerRef }) {
         y1={line.y1}
         x2={line.x2}
         y2={line.y2}
-        stroke={ARROW_COLOR}
+        stroke={color}
         strokeWidth={2.5}
         markerEnd="url(#last-move-arrowhead)"
       />
@@ -99,6 +103,8 @@ LastMoveArrow.propTypes = {
   lastMove: PropTypes.shape({
     source: PropTypes.arrayOf(PropTypes.number),
     target: PropTypes.arrayOf(PropTypes.number),
+    affiliation: PropTypes.number,
   }),
   containerRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }).isRequired,
+  viewerAffiliation: PropTypes.number,
 };

--- a/src/components/GameBoard/index.jsx
+++ b/src/components/GameBoard/index.jsx
@@ -215,7 +215,11 @@ export default function GameBoard({
 
           <Box ref={gridContainerRef} sx={{ position: 'relative' }}>
             <ConnectionLines containerRef={gridContainerRef} />
-            <LastMoveArrow lastMove={lastMove} containerRef={gridContainerRef} />
+            <LastMoveArrow
+              lastMove={lastMove}
+              containerRef={gridContainerRef}
+              viewerAffiliation={affiliation}
+            />
             <Grid columns={20} gutter={6}>
               {combined.map((cell) => cell)}
             </Grid>

--- a/src/contexts/GameContext.jsx
+++ b/src/contexts/GameContext.jsx
@@ -327,7 +327,9 @@ export const GameProvider = ({ children }) => {
       if (data.board) setMyBoard(data.board);
       if (Array.isArray(data.deadPieces)) setMyDeadPieces(data.deadPieces);
       if (Array.isArray(data.moves) && data.moves.length) {
-        setLastMove(data.moves[data.moves.length - 1]);
+        // turn is whose turn is next, so the mover is the other affiliation
+        const affiliation = typeof data.turn === 'number' ? 1 - (data.turn % 2) : undefined;
+        setLastMove({ ...data.moves[data.moves.length - 1], affiliation });
       }
       if (data.phase === 3) {
         setWinner(data.winnerIndex);
@@ -426,7 +428,9 @@ export const GameProvider = ({ children }) => {
       setMyBoard(board);
       setMyDeadPieces(deadPieces);
       if (Array.isArray(moves) && moves.length) {
-        setLastMove(moves[moves.length - 1]);
+        // turn is whose turn is next, so the mover is the other affiliation
+        const affiliation = typeof turn === 'number' ? 1 - (turn % 2) : undefined;
+        setLastMove({ ...moves[moves.length - 1], affiliation });
       }
     });
 

--- a/src/views/Game.jsx
+++ b/src/views/Game.jsx
@@ -87,6 +87,7 @@ const Game = () => {
     ? {
         source: host ? lastMove.source : rotateMove(lastMove.source),
         target: host ? lastMove.target : rotateMove(lastMove.target),
+        affiliation: lastMove.affiliation,
       }
     : null;
 
@@ -101,7 +102,7 @@ const Game = () => {
       // the authoritative board once the server responds, which also
       // corrects any guess this couldn't make (an attack on a fogged piece)
       setMyBoard((board) => applyMoveOptimistically(board, moveSource, moveTarget, gameConfig));
-      setLastMove({ source: moveSource, target: moveTarget });
+      setLastMove({ source: moveSource, target: moveTarget, affiliation });
       setMoveInFlight(true);
 
       socket.emit('playerMakeMove', {


### PR DESCRIPTION
## Summary
- Move history arrows were a single color regardless of who moved, making it impossible to tell at a glance whether the last move was yours, your opponent's, or the AI's (#186).
- Attaches an `affiliation` field to `lastMove` wherever it's set (server events in `GameContext.jsx`, and the optimistic local update in `Game.jsx`), then `LastMoveArrow` colors the arrow blue for the viewer's own moves and red otherwise.

<img width="904" height="1316" alt="image-1784644007353" src="https://github.com/user-attachments/assets/b08fb228-c4c1-4fee-9727-f8433d8cb8fb" />
<img width="904" height="1316" alt="image-1784643957626" src="https://github.com/user-attachments/assets/f5e62b47-a8bf-4f79-bb95-4ca93dfd83aa" />


## Test plan
- [x] `npm run lint` / `npm run build`
- [x] Verified live against a local backend + MongoDB: played an AI game, confirmed the opponent's move arrow renders crimson and the player's own move arrow renders dodgerblue

Closes #186